### PR TITLE
Integrate basic Supabase setup

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,2 @@
+NEXT_PUBLIC_SUPABASE_URL=your-supabase-url
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.local.example
 
 # vercel
 .vercel

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "@mui/material": "^7.0.2",
     "next": "15.3.1",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "@supabase/supabase-js": "^2.39.5"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/scripts/seedSupabase.ts
+++ b/scripts/seedSupabase.ts
@@ -1,0 +1,17 @@
+import { createClient } from '@supabase/supabase-js'
+import { preProduct } from '../src/app/dummyData'
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
+const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+const supabase = createClient(supabaseUrl, supabaseKey)
+
+async function seed() {
+  const { error } = await supabase.from('products').insert(preProduct)
+  if (error) {
+    console.error('Failed to seed products', error)
+  } else {
+    console.log('Products seeded successfully')
+  }
+}
+
+seed()

--- a/src/app/api/products/route.ts
+++ b/src/app/api/products/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server'
+import { supabase } from '@/lib/supabaseClient'
+
+export async function GET() {
+  const { data, error } = await supabase.from('products').select('*')
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+  return NextResponse.json(data)
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,7 @@ import { Typography } from '@mui/material';
 import { useMediaQuery } from '@mui/material';
 import { PRODUCTS } from './dummyData';
 import { ProductCard } from './components/productCard';
+import { useEffect } from 'react';
 import { GridLegacy as Grid } from '@mui/material';  
 
 const marqueeImages = [
@@ -28,6 +29,14 @@ const scroll = keyframes`
 
 export default function Home() {
   const isMobile = useMediaQuery('(max-width:600px)');
+  useEffect(() => {
+    async function fetchProducts() {
+      const res = await fetch('/api/products');
+      const data = await res.json();
+      console.log('Products from API:', data);
+    }
+    fetchProducts();
+  }, []);
 
   return (
     <Box

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js'
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
+const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+
+export const supabase = createClient(supabaseUrl, supabaseKey)

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1,0 +1,47 @@
+-- SQL schema for Supabase tables
+
+create table if not exists users (
+  id uuid primary key default uuid_generate_v4(),
+  email text unique not null,
+  password_hash text not null,
+  name text,
+  address text,
+  created_at timestamp with time zone default current_timestamp
+);
+
+create table if not exists products (
+  id integer primary key,
+  title text not null,
+  subtitle text,
+  price numeric,
+  img text,
+  label text,
+  item text,
+  color text,
+  size text,
+  image text,
+  created_at timestamp with time zone default current_timestamp
+);
+
+create table if not exists wishlist (
+  id bigint generated always as identity primary key,
+  user_id uuid references users(id) on delete cascade,
+  product_id integer references products(id) on delete cascade,
+  created_at timestamp with time zone default current_timestamp
+);
+
+create table if not exists cart (
+  id bigint generated always as identity primary key,
+  user_id uuid references users(id) on delete cascade,
+  product_id integer references products(id) on delete cascade,
+  quantity integer default 1,
+  created_at timestamp with time zone default current_timestamp
+);
+
+create table if not exists orders (
+  id bigint generated always as identity primary key,
+  user_id uuid references users(id) on delete cascade,
+  status text,
+  total_amount numeric,
+  created_at timestamp with time zone default current_timestamp
+);


### PR DESCRIPTION
## Summary
- add Supabase dependency and env example
- initialise Supabase client
- provide SQL schema and seeding script
- expose `/api/products` route using Supabase
- fetch products on the home page

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68503b640174832fb24e4f43db7a975a