### PR TITLE
Add Supabase auth

### DIFF
--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -1,10 +1,28 @@
-import React from 'react'
+'use client'
+import React, { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { Button } from '@mui/material'
 import AccountPage from '../components/account'
+import { useAuth } from '../components/AuthProvider'
 
 const Account = () => {
+  const { user, signOut } = useAuth()
+  const router = useRouter()
+
+  useEffect(() => {
+    if (user === null) {
+      router.replace('/login')
+    }
+  }, [user, router])
+
+  if (!user) return null
+
   return (
-    <div style={{backgroundColor:'#fff', height:'100vh'}}>
-        <AccountPage />
+    <div style={{ backgroundColor: '#fff', minHeight: '100vh' }}>
+      <div style={{ padding: 16 }}>
+        <Button variant='outlined' onClick={signOut}>Sign Out</Button>
+      </div>
+      <AccountPage />
     </div>
   )
 }

--- a/src/app/cart/page.tsx
+++ b/src/app/cart/page.tsx
@@ -1,7 +1,21 @@
-import React from 'react'
+'use client'
+import React, { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
 import CartPage from '../components/cart'
+import { useAuth } from '../components/AuthProvider'
 
 const Cart = () => {
+  const { user } = useAuth()
+  const router = useRouter()
+
+  useEffect(() => {
+    if (user === null) {
+      router.replace('/login')
+    }
+  }, [user, router])
+
+  if (!user) return null
+
   return (
     <div style={{
       backgroundColor: '#fff',
@@ -9,7 +23,7 @@ const Cart = () => {
       display: 'flex',
       flexDirection: 'column',
     }}>
-        <CartPage />
+      <CartPage />
     </div>
   )
 }

--- a/src/app/components/AuthProvider/index.tsx
+++ b/src/app/components/AuthProvider/index.tsx
@@ -1,0 +1,39 @@
+'use client'
+import { createContext, useContext, useEffect, useState } from 'react'
+import { supabase } from '@/lib/supabaseClient'
+import type { User } from '@supabase/supabase-js'
+
+interface AuthContextValue {
+  user: User | null
+  signOut: () => Promise<void>
+}
+
+const AuthContext = createContext<AuthContextValue>({
+  user: null,
+  signOut: async () => {}
+})
+
+export const useAuth = () => useContext(AuthContext)
+
+export default function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<User | null>(null)
+
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data }) => {
+      setUser(data.user)
+    })
+    const { data: listener } = supabase.auth.onAuthStateChange((_event, session) => {
+      setUser(session?.user ?? null)
+    })
+    return () => {
+      listener.subscription.unsubscribe()
+    }
+  }, [])
+
+  const signOut = async () => {
+    await supabase.auth.signOut()
+    setUser(null)
+  }
+
+  return <AuthContext.Provider value={{ user, signOut }}>{children}</AuthContext.Provider>
+}

--- a/src/app/components/header/index.tsx
+++ b/src/app/components/header/index.tsx
@@ -21,12 +21,14 @@ import AccordionSummary from '@mui/material/AccordionSummary';
 import AccordionDetails from '@mui/material/AccordionDetails';
 import styles from './index.module.css';          // <-- your CSS file
 import { MENUS } from '@/app/dummyData';
-import { Typography } from '@mui/material';
+import { Typography } from '@mui/material'
+import { useAuth } from '../AuthProvider'
 
 export default function Header() {
   const router = useRouter();
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+  const { user } = useAuth();
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const [activeMenu, setActiveMenu] = useState<number | null>(null);
   const [search, setSearch] = useState('');
@@ -185,17 +187,17 @@ export default function Header() {
       <div className={styles.actions}>
         <FavoriteBorderOutlined
           className={styles.icon}
-          onClick={() => router.push('/wishlist')}
+          onClick={() => router.push(user ? '/wishlist' : '/login')}
           style={{ cursor: 'pointer' }}
         />
         <AccountCircleIcon
           className={styles.icon}
-          onClick={() => router.push('/account')}
+          onClick={() => router.push(user ? '/account' : '/login')}
           style={{ cursor: 'pointer' }}
         />
         <ShoppingCartIcon
           className={styles.icon}
-          onClick={() => router.push('/cart')}
+          onClick={() => router.push(user ? '/cart' : '/login')}
           style={{ cursor: 'pointer' }}
         />
       </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
-import Header from './components/header';
-import Footer from './components/footer';  
-import MuiTheme from './components/ThemeProvider';
+import Header from './components/header'
+import Footer from './components/footer'
+import MuiTheme from './components/ThemeProvider'
+import AuthProvider from './components/AuthProvider'
 import { Box } from '@mui/material';
 import { Bagel_Fat_One } from 'next/font/google';
 
@@ -25,17 +26,19 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           overflowX: 'hidden',
         }}
       >
-        <Header />
-        <main style={{ flex: 1 }}>
-          <MuiTheme>
-            <Box sx={{ 
-              margin: { xs: '8vh 0 6vh 0', sm: '10vh 0 8vh 0' },
-            }}>
-              {children}
-            </Box>
-          </MuiTheme>
-        </main>
-        <Footer />                         
+        <AuthProvider>
+          <Header />
+          <main style={{ flex: 1 }}>
+            <MuiTheme>
+              <Box sx={{
+                margin: { xs: '8vh 0 6vh 0', sm: '10vh 0 8vh 0' },
+              }}>
+                {children}
+              </Box>
+            </MuiTheme>
+          </main>
+          <Footer />
+        </AuthProvider>
       </body>
     </html>
   );

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,35 @@
+'use client'
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { TextField, Button, Box, Typography } from '@mui/material'
+import { supabase } from '@/lib/supabaseClient'
+
+export default function LoginPage() {
+  const router = useRouter()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const { error } = await supabase.auth.signInWithPassword({ email, password })
+    if (error) {
+      setError(error.message)
+    } else {
+      router.push('/account')
+    }
+  }
+
+  return (
+    <Box sx={{ bgcolor: '#fff', minHeight: '100vh', display: 'flex', flexDirection: 'column', alignItems: 'center', pt: 8 }}>
+      <Typography variant='h5' color='black' sx={{ mb: 2 }}>Login</Typography>
+      <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: 16, width: 300 }}>
+        <TextField label='Email' type='email' value={email} onChange={e => setEmail(e.target.value)} required />
+        <TextField label='Password' type='password' value={password} onChange={e => setPassword(e.target.value)} required />
+        {error && <Typography color='error' variant='body2'>{error}</Typography>}
+        <Button type='submit' variant='contained'>Login</Button>
+      </form>
+      <Button sx={{ mt: 2 }} onClick={() => router.push('/signup')}>Create Account</Button>
+    </Box>
+  )
+}

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,0 +1,35 @@
+'use client'
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { TextField, Button, Box, Typography } from '@mui/material'
+import { supabase } from '@/lib/supabaseClient'
+
+export default function SignUpPage() {
+  const router = useRouter()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const { error } = await supabase.auth.signUp({ email, password })
+    if (error) {
+      setError(error.message)
+    } else {
+      router.push('/login')
+    }
+  }
+
+  return (
+    <Box sx={{ bgcolor: '#fff', minHeight: '100vh', display: 'flex', flexDirection: 'column', alignItems: 'center', pt: 8 }}>
+      <Typography variant='h5' color='black' sx={{ mb: 2 }}>Sign Up</Typography>
+      <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: 16, width: 300 }}>
+        <TextField label='Email' type='email' value={email} onChange={e => setEmail(e.target.value)} required />
+        <TextField label='Password' type='password' value={password} onChange={e => setPassword(e.target.value)} required />
+        {error && <Typography color='error' variant='body2'>{error}</Typography>}
+        <Button type='submit' variant='contained'>Create Account</Button>
+      </form>
+      <Button sx={{ mt: 2 }} onClick={() => router.push('/login')}>Back to Login</Button>
+    </Box>
+  )
+}

--- a/src/app/wishlist/page.tsx
+++ b/src/app/wishlist/page.tsx
@@ -1,7 +1,21 @@
-import React from 'react'
+'use client'
+import React, { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
 import WishlistPage from '../components/wishList'
+import { useAuth } from '../components/AuthProvider'
 
 const WishList = () => {
+  const { user } = useAuth()
+  const router = useRouter()
+
+  useEffect(() => {
+    if (user === null) {
+      router.replace('/login')
+    }
+  }, [user, router])
+
+  if (!user) return null
+
   return (
     <div style={{
       backgroundColor: '#fff',


### PR DESCRIPTION
## Summary
- integrate AuthProvider using Supabase
- wrap layout with AuthProvider
- create login and sign up pages
- guard account, cart and wishlist pages
- update header links depending on authentication

## Testing
- `npm run lint` *(fails: `next` not found / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6850700a2d20832f98ca91cd8f9b11a5