### PR TITLE
Implement profile/address APIs

### DIFF
--- a/src/app/api/addresses/route.ts
+++ b/src/app/api/addresses/route.ts
@@ -1,0 +1,91 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { supabase } from '@/lib/supabaseClient'
+
+async function getUser() {
+  const { data, error } = await supabase.auth.getUser()
+  if (error || !data.user) {
+    return { user: null, error }
+  }
+  return { user: data.user, error: null }
+}
+
+export async function GET() {
+  const { user, error } = await getUser()
+  if (error || !user) {
+    return NextResponse.json({ error: error?.message ?? 'Not authenticated' }, { status: 401 })
+  }
+
+  const { data, error: dbError } = await supabase
+    .from('addresses')
+    .select('*')
+    .eq('user_id', user.id)
+
+  if (dbError) {
+    return NextResponse.json({ error: dbError.message }, { status: 500 })
+  }
+  return NextResponse.json(data)
+}
+
+export async function POST(request: NextRequest) {
+  const { user, error } = await getUser()
+  if (error || !user) {
+    return NextResponse.json({ error: error?.message ?? 'Not authenticated' }, { status: 401 })
+  }
+
+  const body = await request.json()
+  const { name, line1, city, state, pincode, phone } = body
+
+  const { data, error: dbError } = await supabase
+    .from('addresses')
+    .insert({ user_id: user.id, name, line1, city, state, pincode, phone })
+    .select()
+    .single()
+
+  if (dbError) {
+    return NextResponse.json({ error: dbError.message }, { status: 500 })
+  }
+  return NextResponse.json(data)
+}
+
+export async function PUT(request: NextRequest) {
+  const { user, error } = await getUser()
+  if (error || !user) {
+    return NextResponse.json({ error: error?.message ?? 'Not authenticated' }, { status: 401 })
+  }
+
+  const body = await request.json()
+  const { id, ...updates } = body
+
+  const { data, error: dbError } = await supabase
+    .from('addresses')
+    .update(updates)
+    .eq('id', id)
+    .eq('user_id', user.id)
+    .select()
+    .single()
+
+  if (dbError) {
+    return NextResponse.json({ error: dbError.message }, { status: 500 })
+  }
+  return NextResponse.json(data)
+}
+
+export async function DELETE(request: NextRequest) {
+  const { user, error } = await getUser()
+  if (error || !user) {
+    return NextResponse.json({ error: error?.message ?? 'Not authenticated' }, { status: 401 })
+  }
+
+  const { id } = await request.json()
+
+  const { error: dbError } = await supabase
+    .from('addresses')
+    .delete()
+    .eq('id', id)
+    .eq('user_id', user.id)
+
+  if (dbError) {
+    return NextResponse.json({ error: dbError.message }, { status: 500 })
+  }
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -1,0 +1,71 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { supabase } from '@/lib/supabaseClient'
+
+async function getUser() {
+  const { data, error } = await supabase.auth.getUser()
+  if (error || !data.user) {
+    return { user: null, error }
+  }
+  return { user: data.user, error: null }
+}
+
+export async function GET() {
+  const { user, error } = await getUser()
+  if (error || !user) {
+    return NextResponse.json({ error: error?.message ?? 'Not authenticated' }, { status: 401 })
+  }
+
+  const { data, error: dbError } = await supabase
+    .from('profiles')
+    .select('*')
+    .eq('user_id', user.id)
+    .single()
+
+  if (dbError) {
+    return NextResponse.json({ error: dbError.message }, { status: 500 })
+  }
+  return NextResponse.json(data)
+}
+
+export async function POST(request: NextRequest) {
+  const { user, error } = await getUser()
+  if (error || !user) {
+    return NextResponse.json({ error: error?.message ?? 'Not authenticated' }, { status: 401 })
+  }
+
+  const body = await request.json()
+  const { name, email, phone, address } = body
+
+  const { data, error: dbError } = await supabase
+    .from('profiles')
+    .insert({ user_id: user.id, name, email, phone, address })
+    .select()
+    .single()
+
+  if (dbError) {
+    return NextResponse.json({ error: dbError.message }, { status: 500 })
+  }
+  return NextResponse.json(data)
+}
+
+export async function PUT(request: NextRequest) {
+  const { user, error } = await getUser()
+  if (error || !user) {
+    return NextResponse.json({ error: error?.message ?? 'Not authenticated' }, { status: 401 })
+  }
+
+  const body = await request.json()
+  const { name, email, phone, address } = body
+
+  const { data, error: dbError } = await supabase
+    .from('profiles')
+    .update({ name, email, phone, address })
+    .eq('user_id', user.id)
+    .select()
+    .single()
+
+  if (dbError) {
+    return NextResponse.json({ error: dbError.message }, { status: 500 })
+  }
+  return NextResponse.json(data)
+}

--- a/src/app/components/account/address/index.tsx
+++ b/src/app/components/account/address/index.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   Card,
   CardContent,
@@ -26,26 +26,7 @@ interface Address {
   phone: string;
 }
 
-const INITIAL_ADDRESSES: Address[] = [
-  {
-    id: 'ADDR‑01',
-    name: 'John Doe',
-    line1: '221B Baker Street',
-    city: 'London',
-    state: 'Greater London',
-    pincode: 'NW1 6XE',
-    phone: '+44 20 7946 0958',
-  },
-  {
-    id: 'ADDR‑02',
-    name: 'John Doe',
-    line1: '742 Evergreen Terrace',
-    city: 'Springfield',
-    state: 'IL',
-    pincode: '62704',
-    phone: '+1 217 555 0113',
-  },
-];
+const INITIAL_ADDRESSES: Address[] = [];
 
 const emptyAddress: Address = {
   id: '',
@@ -60,8 +41,14 @@ const emptyAddress: Address = {
 export default function AddressesSection() {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
-  
+
   const [addresses, setAddresses] = useState<Address[]>(INITIAL_ADDRESSES);
+
+  useEffect(() => {
+    fetch('/api/addresses')
+      .then(res => res.ok ? res.json() : [])
+      .then(data => setAddresses(data))
+  }, [])
 
   // Modal control and form state
   const [open, setOpen] = useState(false);
@@ -92,23 +79,43 @@ export default function AddressesSection() {
   };
 
   // Add or update address
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
     if (editId) {
-      // Update
-      setAddresses(addresses.map(addr => addr.id === editId ? { ...form, id: editId } : addr));
+      const res = await fetch('/api/addresses', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: editId, ...form })
+      })
+      if (res.ok) {
+        const data = await res.json()
+        setAddresses(addresses.map(addr => addr.id === editId ? data : addr))
+      }
     } else {
-      // Add new
-      const newAddress: Address = { ...form, id: `ADDR-${Date.now()}` };
-      setAddresses([newAddress, ...addresses]);
+      const res = await fetch('/api/addresses', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(form)
+      })
+      if (res.ok) {
+        const data = await res.json()
+        setAddresses([data, ...addresses])
+      }
     }
-    setOpen(false);
-  };
+    setOpen(false)
+  }
 
   // Delete address
-  const handleDelete = (id: string) => {
-    setAddresses(addresses.filter(addr => addr.id !== id));
-  };
+  const handleDelete = async (id: string) => {
+    const res = await fetch('/api/addresses', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id })
+    })
+    if (res.ok) {
+      setAddresses(addresses.filter(addr => addr.id !== id))
+    }
+  }
 
   return (
     <>

--- a/src/app/components/account/profile/index.tsx
+++ b/src/app/components/account/profile/index.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   Card,
   CardContent,
@@ -18,23 +18,31 @@ export default function ProfileSection() {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   
-  // State for profile info
-  const [profile, setProfile] = useState({
-    name: 'John Doe',
-    email: 'john.doe@example.com',
-    phone: '+1 217 555 0113'
-  });
+  const [profile, setProfile] = useState<{ name: string; email: string; phone: string } | null>(null)
+
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    fetch('/api/profile')
+      .then(res => res.ok ? res.json() : null)
+      .then(data => {
+        if (data) {
+          setProfile({ name: data.name ?? '', email: data.email ?? '', phone: data.phone ?? '' })
+          setForm({ name: data.name ?? '', email: data.email ?? '', phone: data.phone ?? '' })
+        }
+        setLoading(false)
+      })
+  }, [])
 
   // State for modal open/close
   const [open, setOpen] = useState(false);
 
-  // State for edit form
-  const [form, setForm] = useState(profile);
+  const [form, setForm] = useState({ name: '', email: '', phone: '' })
 
   const handleOpen = () => {
-    setForm(profile); // Reset form to current profile
-    setOpen(true);
-  };
+    setForm(profile ?? { name: '', email: '', phone: '' })
+    setOpen(true)
+  }
 
   const handleClose = () => setOpen(false);
 
@@ -44,11 +52,22 @@ export default function ProfileSection() {
   };
 
   // Submit form: update main profile state
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    setProfile(form);
-    setOpen(false);
-  };
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const method = profile ? 'PUT' : 'POST'
+    const res = await fetch('/api/profile', {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form)
+    })
+    if (res.ok) {
+      const data = await res.json()
+      setProfile({ name: data.name, email: data.email, phone: data.phone })
+    }
+    setOpen(false)
+  }
+
+  if (loading) return null
 
   return (
     <>
@@ -69,9 +88,9 @@ export default function ProfileSection() {
             Personal Information
           </Typography>
           <Stack spacing={1}>
-            <Typography color="black" sx={{ fontFamily: 'sans-serif' }}>Name: {profile.name}</Typography>
-            <Typography color="black" sx={{ fontFamily: 'sans-serif' }}>Email: {profile.email}</Typography>
-            <Typography color="black" sx={{ fontFamily: 'sans-serif' }}>Phone: {profile.phone}</Typography>
+            <Typography color="black" sx={{ fontFamily: 'sans-serif' }}>Name: {profile?.name || ''}</Typography>
+            <Typography color="black" sx={{ fontFamily: 'sans-serif' }}>Email: {profile?.email || ''}</Typography>
+            <Typography color="black" sx={{ fontFamily: 'sans-serif' }}>Phone: {profile?.phone || ''}</Typography>
           </Stack>
           <Button 
             variant="contained" 

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -4,6 +4,8 @@
 create table if not exists profiles (
   user_id uuid primary key references auth.users(id) on delete cascade,
   name text,
+  email text,
+  phone text,
   address text,
   created_at timestamp with time zone default current_timestamp
 );
@@ -65,4 +67,32 @@ WITH CHECK (auth.uid() = user_id);
 CREATE POLICY "Allow authenticated user to update own profile"
 ON public.profiles
 FOR UPDATE
+USING (auth.uid() = user_id);
+
+-- Allow authenticated users to view their own profile
+CREATE POLICY "Allow authenticated user to view own profile"
+ON public.profiles
+FOR SELECT
+USING (auth.uid() = user_id);
+
+-- Addresses table for multiple addresses per user
+create table if not exists addresses (
+  id bigint generated always as identity primary key,
+  user_id uuid references auth.users(id) on delete cascade,
+  name text,
+  line1 text,
+  city text,
+  state text,
+  pincode text,
+  phone text,
+  created_at timestamp with time zone default current_timestamp
+);
+
+-- Enable RLS for addresses
+ALTER TABLE public.addresses ENABLE ROW LEVEL SECURITY;
+
+-- Policies for addresses
+CREATE POLICY "Allow authenticated user to manage own addresses"
+ON public.addresses
+FOR ALL
 USING (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- add email and phone fields to `profiles` and add `addresses` table
- create `/api/profile` and `/api/addresses` endpoints
- wire account profile and address components to the new APIs

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68542a7db010832fa8af17fe91dc1933