### PR TITLE
Fix profile fetching

### DIFF
--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -24,12 +24,12 @@ export async function GET(request: NextRequest) {
     .from('profiles')
     .select('*')
     .eq('user_id', user.id)
-    .single()
+    .maybeSingle()
 
   if (dbError) {
     return NextResponse.json({ error: dbError.message }, { status: 500 })
   }
-  return NextResponse.json(data)
+  return NextResponse.json(data ?? null)
 }
 
 export async function POST(request: NextRequest) {

--- a/src/app/components/account/profile/index.tsx
+++ b/src/app/components/account/profile/index.tsx
@@ -23,6 +23,9 @@ export default function ProfileSection() {
 
   const [loading, setLoading] = useState(true)
 
+  // State for modal open/close
+  const [open, setOpen] = useState(false);
+
   useEffect(() => {
     supabase.auth.getSession().then(({ data: { session } }) => {
       const headers: Record<string, string> = {}
@@ -33,14 +36,13 @@ export default function ProfileSection() {
           if (data) {
             setProfile({ name: data.name ?? '', email: data.email ?? '', phone: data.phone ?? '' })
             setForm({ name: data.name ?? '', email: data.email ?? '', phone: data.phone ?? '' })
+          } else {
+            setOpen(true)
           }
           setLoading(false)
         })
     })
   }, [])
-
-  // State for modal open/close
-  const [open, setOpen] = useState(false);
 
   const [form, setForm] = useState({ name: '', email: '', phone: '' })
 


### PR DESCRIPTION
## Summary
- avoid errors when a profile row is missing
- auto-open profile modal if none exists

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68544e2b91a0832fa1db49df859b7ca0