### PR TITLE
Optimize product state lookups

### DIFF
--- a/src/app/components/productCard/index.tsx
+++ b/src/app/components/productCard/index.tsx
@@ -19,14 +19,19 @@ export interface Product {
   image: string;
 }
 
-export const ProductCard: React.FC<{ product: Product }> = ({ product }) => {
+export const ProductCard: React.FC<{
+  product: Product;
+  initialIsWished?: boolean;
+  initialCartQty?: number;
+}> = ({ product, initialIsWished, initialCartQty }) => {
   const router = useRouter();
   const { user } = useAuth();
-  const [isWished, setIsWished] = useState(false);
-  const [cartQty, setCartQty] = useState(0);
+  const [isWished, setIsWished] = useState(initialIsWished ?? false);
+  const [cartQty, setCartQty] = useState(initialCartQty ?? 0);
 
   useEffect(() => {
     if (!user) return;
+    if (initialIsWished !== undefined && initialCartQty !== undefined) return;
     supabase.auth.getSession().then(({ data: { session } }) => {
       const headers: Record<string, string> = {};
       if (session) headers['Authorization'] = `Bearer ${session.access_token}`;
@@ -37,7 +42,15 @@ export const ProductCard: React.FC<{ product: Product }> = ({ product }) => {
         .then(res => res.ok ? res.json() : null)
         .then(data => setCartQty(data?.quantity ?? 0));
     });
-  }, [user, product.id]);
+  }, [user, product.id, initialIsWished, initialCartQty]);
+
+  useEffect(() => {
+    if (initialIsWished !== undefined) setIsWished(initialIsWished);
+  }, [initialIsWished]);
+
+  useEffect(() => {
+    if (initialCartQty !== undefined) setCartQty(initialCartQty);
+  }, [initialCartQty]);
 
   // Handlers
   const handleWishlistToggle = async (e: React.MouseEvent<HTMLButtonElement>) => {


### PR DESCRIPTION
## Summary
- pass wishlist and cart data to `ProductCard` to avoid fetching per item
- fetch wishlist and cart once on Home and Catalogue pages

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685463f3bf60832fbe0133a744992eb2