### PR TITLE
Align desktop styles with laptop

### DIFF
--- a/src/app/cancelRefund/page.tsx
+++ b/src/app/cancelRefund/page.tsx
@@ -50,7 +50,7 @@ export default function CancelRefundPage() {
   ];
 
   return (
-    <Container maxWidth="lg" sx={{ py: 6 }}>
+    <Container maxWidth="md" sx={{ py: 6 }}>
       <Box sx={{ textAlign: 'center', mb: 6 }}>
         <Typography variant="h3" component="h1" sx={{ 
           fontWeight: 700, 
@@ -75,7 +75,7 @@ export default function CancelRefundPage() {
       <Divider sx={{ mb: 6 }} />
 
       {/* FAQ Section */}
-      <Paper elevation={3} sx={{ p: { xs: 3, md: 6 }, borderRadius: 3, mb: 6 }}>
+      <Paper elevation={3} sx={{ p: { xs: 3, md: 6, lg: 6 }, borderRadius: 3, mb: 6 }}>
         <Stack spacing={3}>
           {faqs.map((faq, index) => (
             <Accordion key={index} sx={{ 
@@ -114,7 +114,7 @@ export default function CancelRefundPage() {
       </Paper>
 
       {/* Contact Section */}
-      <Paper elevation={3} sx={{ p: { xs: 3, md: 6 }, borderRadius: 3, textAlign: 'center' }}>
+      <Paper elevation={3} sx={{ p: { xs: 3, md: 6, lg: 6 }, borderRadius: 3, textAlign: 'center' }}>
         <Stack spacing={3} alignItems="center">
           <HelpIcon sx={{ fontSize: 48, color: 'primary.main' }} />
           <Typography variant="h4" sx={{ fontWeight: 700, color: 'primary.main' }}>

--- a/src/app/components/cart/index.tsx
+++ b/src/app/components/cart/index.tsx
@@ -263,11 +263,11 @@ export default function CartPage({ buyNowProductId }: { buyNowProductId?: string
         >
             {/* 2. MAIN CONTENT GROWS - px: 0 ensures no double padding */}
             <Container
-                maxWidth="lg"
+                maxWidth="md"
                 sx={{
                     flex: '1 0 auto',
-                    py: { xs: 2, md: 4 },
-                    px: { xs: 1, sm: 2, md: 4 },
+                    py: { xs: 2, md: 4, lg: 4 },
+                    px: { xs: 1, sm: 2, md: 4, lg: 4 },
                     boxSizing: 'border-box',
                     width: '100%',
                     minWidth: 0,
@@ -277,9 +277,9 @@ export default function CartPage({ buyNowProductId }: { buyNowProductId?: string
                     variant="h4"
                     sx={{
                         fontWeight: 700,
-                        mb: { xs: 2, md: 4 },
+                        mb: { xs: 2, md: 4, lg: 4 },
                         color: '#1a1a1a',
-                        fontSize: { xs: '1.5rem', md: '2rem' },
+                        fontSize: { xs: '1.5rem', md: '2rem', lg: '2rem' },
                         fontFamily: 'sans-serif',
                         wordBreak: 'break-word',
                     }}
@@ -288,8 +288,8 @@ export default function CartPage({ buyNowProductId }: { buyNowProductId?: string
                 </Typography>
 
                 <Stack
-                    direction={{ xs: 'column', md: 'row' }}
-                    spacing={{ xs: 2, md: 4 }}
+                    direction={{ xs: 'column', md: 'row', lg: 'row' }}
+                    spacing={{ xs: 2, md: 4, lg: 4 }}
                     alignItems="flex-start"
                     sx={{ width: '100%', minWidth: 0, flexGrow: 1 }}
                 >
@@ -298,7 +298,7 @@ export default function CartPage({ buyNowProductId }: { buyNowProductId?: string
                         flex: 1,
                         width: '100%',
                         minWidth: 0,
-                        mb: { xs: 2, md: 0 },
+                        mb: { xs: 2, md: 0, lg: 0 },
                         boxSizing: 'border-box',
                     }}>
                         {cart.length === 0 ? (
@@ -332,7 +332,7 @@ export default function CartPage({ buyNowProductId }: { buyNowProductId?: string
                                 <Paper
                                     elevation={0}
                                     sx={{
-                                        p: { xs: 1.5, md: 3 },
+                                        p: { xs: 1.5, md: 3, lg: 3 },
                                         mb: 2,
                                         bgcolor: 'white',
                                         borderRadius: 2,
@@ -469,7 +469,7 @@ export default function CartPage({ buyNowProductId }: { buyNowProductId?: string
                                 <Paper
                                     elevation={0}
                                     sx={{
-                                        p: { xs: 1.5, md: 3 },
+                                        p: { xs: 1.5, md: 3, lg: 3 },
                                         bgcolor: 'white',
                                         borderRadius: 2,
                                         width: '100%',
@@ -517,7 +517,7 @@ export default function CartPage({ buyNowProductId }: { buyNowProductId?: string
 
                     {/* Right Column - Address & Payment */}
                     <Box sx={{
-                        width: { xs: '100%', md: 400 },
+                        width: { xs: '100%', md: 400, lg: 400 },
                         minWidth: 0,
                         boxSizing: 'border-box',
                     }}>
@@ -525,7 +525,7 @@ export default function CartPage({ buyNowProductId }: { buyNowProductId?: string
                         <Paper
                             elevation={0}
                             sx={{
-                                p: { xs: 1.5, md: 3 },
+                                p: { xs: 1.5, md: 3, lg: 3 },
                                 mb: 2,
                                 bgcolor: 'white',
                                 borderRadius: 2,
@@ -642,7 +642,7 @@ export default function CartPage({ buyNowProductId }: { buyNowProductId?: string
                         <Paper
                             elevation={0}
                             sx={{
-                                p: { xs: 1.5, md: 3 },
+                                p: { xs: 1.5, md: 3, lg: 3 },
                                 mb: 2,
                                 bgcolor: 'white',
                                 borderRadius: 2,

--- a/src/app/components/footer/index.tsx
+++ b/src/app/components/footer/index.tsx
@@ -16,11 +16,11 @@ export default function Footer() {
         color: '#fff',
       }}
     >
-      <Container maxWidth="lg">
-        <Box sx={{ px: { xs: 2, sm: 3 }, py: { xs: 3, sm: 4 } }}>
+      <Container maxWidth="md">
+        <Box sx={{ px: { xs: 2, sm: 3, md: 3, lg: 3 }, py: { xs: 3, sm: 4, md: 4, lg: 4 } }}>
           <Grid container spacing={4}>
             {/* Left Column: Policies */}
-            <Grid size={{ xs: 12, sm: 6 }}>
+            <Grid size={{ xs: 12, sm: 6, md: 6, lg: 6 }}>
               <Stack spacing={3}>
                 {/* Policies */}
                 <Box>
@@ -38,7 +38,7 @@ export default function Footer() {
               </Stack>
             </Grid>
             {/* Right Column: Newsletter & Follow Us */}
-            <Grid size={{ xs: 12, sm: 6 }}>
+            <Grid size={{ xs: 12, sm: 6, md: 6, lg: 6 }}>
               <Stack spacing={3}>
                 {/* Newsletter */}
                 <Box>

--- a/src/app/returnPolicy/page.tsx
+++ b/src/app/returnPolicy/page.tsx
@@ -6,14 +6,14 @@ const ReturnPolicy = () => {
       sx={{ 
         minHeight: '100vh', 
         background: 'linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%)',
-        py: { xs: 4, md: 8 }
+        py: { xs: 4, md: 8 , lg: 8 }
       }}
     >
-      <Container maxWidth="lg">
+      <Container maxWidth="md">
         <Paper 
           elevation={0}
           sx={{ 
-            p: { xs: 4, md: 8 }, 
+            p: { xs: 4, md: 8 , lg: 8 }, 
             bgcolor: '#ffffff',
             borderRadius: 3,
             boxShadow: '0 8px 32px rgba(0,0,0,0.1)',
@@ -37,7 +37,7 @@ const ReturnPolicy = () => {
               variant="h2" 
               fontWeight={700} 
               mb={3} 
-              fontSize={{ xs: '2rem', md: '3rem' }}
+              fontSize={{ xs: '2rem', md: '3rem' , lg: '3rem' }}
               sx={{
                 background: 'linear-gradient(45deg, #1976d2, #42a5f5)',
                 backgroundClip: 'text',
@@ -49,7 +49,7 @@ const ReturnPolicy = () => {
               Return & Exchange Policy
             </Typography>
             <Typography 
-              fontSize={{ xs: '1.1rem', md: '1.25rem' }} 
+              fontSize={{ xs: '1.1rem', md: '1.25rem' , lg: '1.25rem' }} 
               lineHeight={1.8} 
               color="#666"
               maxWidth={600}
@@ -83,7 +83,7 @@ const ReturnPolicy = () => {
                 variant="h4" 
                 fontWeight={600} 
                 mb={3} 
-                fontSize={{ xs: '1.3rem', md: '1.5rem' }}
+                fontSize={{ xs: '1.3rem', md: '1.5rem' , lg: '1.5rem' }}
                 color="#1a1a1a"
                 sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
               >
@@ -91,7 +91,7 @@ const ReturnPolicy = () => {
                 Can I return or exchange my product?
               </Typography>
               
-              <Typography fontSize={{ xs: '1rem', md: '1.1rem' }} lineHeight={1.8} mb={3} color="#333">
+              <Typography fontSize={{ xs: '1rem', md: '1.1rem' , lg: '1.1rem' }} lineHeight={1.8} mb={3} color="#333">
                 You can request a return or exchange only if the item is:
               </Typography>
               
@@ -105,7 +105,7 @@ const ReturnPolicy = () => {
                   <Typography 
                     key={index}
                     component="li" 
-                    fontSize={{ xs: '1rem', md: '1.1rem' }} 
+                    fontSize={{ xs: '1rem', md: '1.1rem' , lg: '1.1rem' }} 
                     lineHeight={1.8} 
                     color="#333"
                     sx={{ mb: 1 }}
@@ -116,13 +116,13 @@ const ReturnPolicy = () => {
               </Box>
               
               <Box sx={{ bgcolor: '#fff3cd', p: 3, borderRadius: 2, border: '1px solid #ffeaa7' }}>
-                <Typography fontSize={{ xs: '0.95rem', md: '1rem' }} lineHeight={1.7} mb={2} color="#333">
+                <Typography fontSize={{ xs: '0.95rem', md: '1rem' , lg: '1rem' }} lineHeight={1.7} mb={2} color="#333">
                   • All returned items must be new, unused, and in their original condition.
                 </Typography>
-                <Typography fontSize={{ xs: '0.95rem', md: '1rem' }} lineHeight={1.7} mb={2} color="#333">
+                <Typography fontSize={{ xs: '0.95rem', md: '1rem' , lg: '1rem' }} lineHeight={1.7} mb={2} color="#333">
                   • Returns will not be accepted if the brand tag or labels is removed from the product.
                 </Typography>
-                <Typography fontSize={{ xs: '0.95rem', md: '1rem' }} lineHeight={1.7} color="#d32f2f" fontWeight={600}>
+                <Typography fontSize={{ xs: '0.95rem', md: '1rem' , lg: '1rem' }} lineHeight={1.7} color="#d32f2f" fontWeight={600}>
                   📌 Change of mind or wrong size orders are not eligible for free return/exchange. You&apos;ll need to place a new order at your cost.
                 </Typography>
               </Box>
@@ -146,7 +146,7 @@ const ReturnPolicy = () => {
                 variant="h4" 
                 fontWeight={600} 
                 mb={3} 
-                fontSize={{ xs: '1.3rem', md: '1.5rem' }}
+                fontSize={{ xs: '1.3rem', md: '1.5rem' , lg: '1.5rem' }}
                 color="#1a1a1a"
                 sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
               >
@@ -155,10 +155,10 @@ const ReturnPolicy = () => {
               </Typography>
               
               <Box sx={{ bgcolor: '#e3f2fd', p: 3, borderRadius: 2, border: '1px solid #bbdefb' }}>
-                <Typography fontSize={{ xs: '1rem', md: '1.1rem' }} lineHeight={1.8} mb={2} color="#333">
+                <Typography fontSize={{ xs: '1rem', md: '1.1rem' , lg: '1.1rem' }} lineHeight={1.8} mb={2} color="#333">
                   All return/exchange claims must be made within <strong>5 days</strong> of product delivery.
                 </Typography>
-                <Typography fontSize={{ xs: '1rem', md: '1.1rem' }} lineHeight={1.8} color="#d32f2f" fontWeight={600}>
+                <Typography fontSize={{ xs: '1rem', md: '1.1rem' , lg: '1.1rem' }} lineHeight={1.8} color="#d32f2f" fontWeight={600}>
                   After this period, the return request will be declined.
                 </Typography>
               </Box>
@@ -182,7 +182,7 @@ const ReturnPolicy = () => {
                 variant="h4" 
                 fontWeight={600} 
                 mb={3} 
-                fontSize={{ xs: '1.3rem', md: '1.5rem' }}
+                fontSize={{ xs: '1.3rem', md: '1.5rem' , lg: '1.5rem' }}
                 color="#1a1a1a"
                 sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
               >
@@ -190,7 +190,7 @@ const ReturnPolicy = () => {
                 What evidence is required to submit a return request?
               </Typography>
               
-              <Typography fontSize={{ xs: '1rem', md: '1.1rem' }} lineHeight={1.8} mb={3} color="#333">
+              <Typography fontSize={{ xs: '1rem', md: '1.1rem' , lg: '1.1rem' }} lineHeight={1.8} mb={3} color="#333">
                 To submit a valid claim, you must provide:
               </Typography>
               
@@ -203,7 +203,7 @@ const ReturnPolicy = () => {
                   <Typography 
                     key={index}
                     component="li" 
-                    fontSize={{ xs: '1rem', md: '1.1rem' }} 
+                    fontSize={{ xs: '1rem', md: '1.1rem' , lg: '1.1rem' }} 
                     lineHeight={1.8} 
                     color="#333"
                     sx={{ mb: 1 }}
@@ -214,7 +214,7 @@ const ReturnPolicy = () => {
               </Box>
               
               <Box sx={{ bgcolor: '#e8f5e8', p: 3, borderRadius: 2, border: '1px solid #c8e6c9' }}>
-                <Typography fontSize={{ xs: '1rem', md: '1.1rem' }} lineHeight={1.8} color="#1976d2" fontWeight={600}>
+                <Typography fontSize={{ xs: '1rem', md: '1.1rem' , lg: '1.1rem' }} lineHeight={1.8} color="#1976d2" fontWeight={600}>
                   📩 Email all documents to: <strong>miniconclothing@gmail.com</strong>
                 </Typography>
               </Box>
@@ -238,7 +238,7 @@ const ReturnPolicy = () => {
                 variant="h4" 
                 fontWeight={600} 
                 mb={3} 
-                fontSize={{ xs: '1.3rem', md: '1.5rem' }}
+                fontSize={{ xs: '1.3rem', md: '1.5rem' , lg: '1.5rem' }}
                 color="#1a1a1a"
                 sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
               >
@@ -247,13 +247,13 @@ const ReturnPolicy = () => {
               </Typography>
               
               <Box sx={{ bgcolor: '#ffebee', p: 3, borderRadius: 2, border: '1px solid #ffcdd2' }}>
-                <Typography fontSize={{ xs: '1rem', md: '1.1rem' }} lineHeight={1.8} mb={2} color="#d32f2f" fontWeight={600}>
+                <Typography fontSize={{ xs: '1rem', md: '1.1rem' , lg: '1.1rem' }} lineHeight={1.8} mb={2} color="#d32f2f" fontWeight={600}>
                   Unfortunately, we do not offer returns or exchanges for incorrect size selection.
                 </Typography>
-                <Typography fontSize={{ xs: '1rem', md: '1.1rem' }} lineHeight={1.8} mb={2} color="#333">
+                <Typography fontSize={{ xs: '1rem', md: '1.1rem' , lg: '1.1rem' }} lineHeight={1.8} mb={2} color="#333">
                   However, you may place a new order at your own expense if you&apos;d like to get a different size.
                 </Typography>
-                <Typography fontSize={{ xs: '1rem', md: '1.1rem' }} lineHeight={1.8} color="#333">
+                <Typography fontSize={{ xs: '1rem', md: '1.1rem' , lg: '1.1rem' }} lineHeight={1.8} color="#333">
                   <strong>Tip:</strong> Always refer to our size chart before placing your order.
                 </Typography>
               </Box>
@@ -277,7 +277,7 @@ const ReturnPolicy = () => {
                 variant="h4" 
                 fontWeight={600} 
                 mb={3} 
-                fontSize={{ xs: '1.3rem', md: '1.5rem' }}
+                fontSize={{ xs: '1.3rem', md: '1.5rem' , lg: '1.5rem' }}
                 color="#1a1a1a"
                 sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
               >
@@ -286,18 +286,18 @@ const ReturnPolicy = () => {
               </Typography>
               
               <Box sx={{ bgcolor: '#fff3e0', p: 3, borderRadius: 2, border: '1px solid #ffcc02' }}>
-                <Typography fontSize={{ xs: '1rem', md: '1.1rem' }} lineHeight={1.8} mb={2} color="#d32f2f" fontWeight={600}>
+                <Typography fontSize={{ xs: '1rem', md: '1.1rem' , lg: '1.1rem' }} lineHeight={1.8} mb={2} color="#d32f2f" fontWeight={600}>
                   If the item was accidentally cut or damaged while opening (e.g. with scissors), we cannot approve a return unless:
                 </Typography>
                 <Box component="ul" sx={{ pl: 3, mb: 2 }}>
-                  <Typography component="li" fontSize={{ xs: '1rem', md: '1.1rem' }} lineHeight={1.8} color="#333" sx={{ mb: 1 }}>
+                  <Typography component="li" fontSize={{ xs: '1rem', md: '1.1rem' , lg: '1.1rem' }} lineHeight={1.8} color="#333" sx={{ mb: 1 }}>
                     A clear unboxing video shows the condition before damage
                   </Typography>
-                  <Typography component="li" fontSize={{ xs: '1rem', md: '1.1rem' }} lineHeight={1.8} color="#333" sx={{ mb: 1 }}>
+                  <Typography component="li" fontSize={{ xs: '1rem', md: '1.1rem' , lg: '1.1rem' }} lineHeight={1.8} color="#333" sx={{ mb: 1 }}>
                     The damage wasn&apos;t caused during unpacking
                   </Typography>
                 </Box>
-                <Typography fontSize={{ xs: '1rem', md: '1.1rem' }} lineHeight={1.8} color="#333" fontWeight={600}>
+                <Typography fontSize={{ xs: '1rem', md: '1.1rem' , lg: '1.1rem' }} lineHeight={1.8} color="#333" fontWeight={600}>
                   Please unbox your order carefully.
                 </Typography>
               </Box>
@@ -321,7 +321,7 @@ const ReturnPolicy = () => {
                 variant="h4" 
                 fontWeight={600} 
                 mb={3} 
-                fontSize={{ xs: '1.3rem', md: '1.5rem' }}
+                fontSize={{ xs: '1.3rem', md: '1.5rem' , lg: '1.5rem' }}
                 color="#1a1a1a"
                 sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
               >
@@ -330,10 +330,10 @@ const ReturnPolicy = () => {
               </Typography>
               
               <Box sx={{ bgcolor: '#f3e5f5', p: 3, borderRadius: 2, border: '1px solid #e1bee7' }}>
-                <Typography fontSize={{ xs: '1rem', md: '1.1rem' }} lineHeight={1.8} mb={2} color="#333">
+                <Typography fontSize={{ xs: '1rem', md: '1.1rem' , lg: '1.1rem' }} lineHeight={1.8} mb={2} color="#333">
                   In select approved return cases, we may help arrange a reverse pickup within 5 days of delivery.
                 </Typography>
-                <Typography fontSize={{ xs: '1rem', md: '1.1rem' }} lineHeight={1.8} color="#1976d2" fontWeight={600}>
+                <Typography fontSize={{ xs: '1rem', md: '1.1rem' , lg: '1.1rem' }} lineHeight={1.8} color="#1976d2" fontWeight={600}>
                   📦 This will be confirmed via email with instructions.
                 </Typography>
               </Box>
@@ -357,7 +357,7 @@ const ReturnPolicy = () => {
                 variant="h4" 
                 fontWeight={600} 
                 mb={3} 
-                fontSize={{ xs: '1.3rem', md: '1.5rem' }}
+                fontSize={{ xs: '1.3rem', md: '1.5rem' , lg: '1.5rem' }}
                 color="#1a1a1a"
                 sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
               >
@@ -365,11 +365,11 @@ const ReturnPolicy = () => {
                 What should I do if the package looks damaged on delivery?
               </Typography>
               
-              <Typography fontSize={{ xs: '1rem', md: '1.1rem' }} lineHeight={1.8} mb={3} color="#333">
+              <Typography fontSize={{ xs: '1rem', md: '1.1rem' , lg: '1.1rem' }} lineHeight={1.8} mb={3} color="#333">
                 Inspect the package before signing from the courier.
               </Typography>
               
-              <Typography fontSize={{ xs: '1rem', md: '1.1rem' }} lineHeight={1.8} mb={2} color="#333">
+              <Typography fontSize={{ xs: '1rem', md: '1.1rem' , lg: '1.1rem' }} lineHeight={1.8} mb={2} color="#333">
                 If you notice visible damage:
               </Typography>
               
@@ -382,7 +382,7 @@ const ReturnPolicy = () => {
                   <Typography 
                     key={index}
                     component="li" 
-                    fontSize={{ xs: '1rem', md: '1.1rem' }} 
+                    fontSize={{ xs: '1rem', md: '1.1rem' , lg: '1.1rem' }} 
                     lineHeight={1.8} 
                     color="#333"
                     sx={{ mb: 1 }}
@@ -393,7 +393,7 @@ const ReturnPolicy = () => {
               </Box>
               
               <Box sx={{ bgcolor: '#e8f5e8', p: 3, borderRadius: 2, border: '1px solid #c8e6c9' }}>
-                <Typography fontSize={{ xs: '1rem', md: '1.1rem' }} lineHeight={1.8} color="#333" fontWeight={600}>
+                <Typography fontSize={{ xs: '1rem', md: '1.1rem' , lg: '1.1rem' }} lineHeight={1.8} color="#333" fontWeight={600}>
                   This helps us raise claims with the courier partner.
                 </Typography>
               </Box>
@@ -416,12 +416,12 @@ const ReturnPolicy = () => {
               variant="h3" 
               fontWeight={700} 
               mb={3} 
-              fontSize={{ xs: '1.5rem', md: '2rem' }}
+              fontSize={{ xs: '1.5rem', md: '2rem' , lg: '2rem' }}
               color="#1a1a1a"
             >
               ❓ Still Need Help?
             </Typography>
-            <Typography fontSize={{ xs: '1.1rem', md: '1.25rem' }} lineHeight={1.8} mb={3} color="#666">
+            <Typography fontSize={{ xs: '1.1rem', md: '1.25rem' , lg: '1.25rem' }} lineHeight={1.8} mb={3} color="#666">
               Reach out anytime at:
             </Typography>
             <Box 
@@ -433,12 +433,12 @@ const ReturnPolicy = () => {
                 py: 2,
                 borderRadius: 2,
                 fontWeight: 600,
-                fontSize: { xs: '1rem', md: '1.1rem' }
+                fontSize: { xs: '1rem', md: '1.1rem' , lg: '1.1rem' }
               }}
             >
               📧 miniconclothing@gmail.com
             </Box>
-            <Typography fontSize={{ xs: '1rem', md: '1.1rem' }} lineHeight={1.8} color="#666" mt={2}>
+            <Typography fontSize={{ xs: '1rem', md: '1.1rem' , lg: '1.1rem' }} lineHeight={1.8} color="#666" mt={2}>
               We&apos;ll respond within 24–48 hours.
             </Typography>
           </Box>

--- a/src/app/shipping/page.tsx
+++ b/src/app/shipping/page.tsx
@@ -43,7 +43,7 @@ export default function ShippingPage() {
   ];
 
   return (
-    <Container maxWidth="lg" sx={{ py: 6 }}>
+    <Container maxWidth="md" sx={{ py: 6 }}>
       <Box sx={{ textAlign: 'center', mb: 6 }}>
         <Typography variant="h3" component="h1" sx={{ 
           fontWeight: 700, 
@@ -68,7 +68,7 @@ export default function ShippingPage() {
       <Divider sx={{ mb: 6 }} />
 
       {/* FAQ Section */}
-      <Paper elevation={3} sx={{ p: { xs: 3, md: 6 }, borderRadius: 3, mb: 6 }}>
+      <Paper elevation={3} sx={{ p: { xs: 3, md: 6, lg: 6 }, borderRadius: 3, mb: 6 }}>
         <Stack spacing={3}>
           {faqs.map((faq, index) => (
             <Accordion key={index} sx={{ 
@@ -107,7 +107,7 @@ export default function ShippingPage() {
       </Paper>
 
       {/* Contact Section */}
-      <Paper elevation={3} sx={{ p: { xs: 3, md: 6 }, borderRadius: 3, textAlign: 'center' }}>
+      <Paper elevation={3} sx={{ p: { xs: 3, md: 6, lg: 6 }, borderRadius: 3, textAlign: 'center' }}>
         <Stack spacing={3} alignItems="center">
           <HelpIcon sx={{ fontSize: 48, color: 'primary.main' }} />
           <Typography variant="h4" sx={{ fontWeight: 700, color: 'primary.main' }}>
@@ -117,7 +117,7 @@ export default function ShippingPage() {
             Reach out anytime.
           </Typography>
           
-          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={3} sx={{ mt: 2 }}>
+          <Stack direction={{ xs: 'column', sm: 'row', md: 'row', lg: 'row' }} spacing={3} sx={{ mt: 2 }}>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
               <EmailIcon sx={{ color: 'primary.main' }} />
               <Typography 


### PR DESCRIPTION
## Summary
- replicate laptop padding and layout settings on desktop screens
- standardize cart, shipping, return, cancel pages and footer

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686914ea166c832f9e3782475f8bc7ce