### PR TITLE
Update CategoryCards images

### DIFF
--- a/src/app/components/categoryCards/index.tsx
+++ b/src/app/components/categoryCards/index.tsx
@@ -3,8 +3,6 @@
 import React from 'react';
 import { Box, Typography } from '@mui/material';
 import Image from 'next/image';
-import { useTheme } from '@mui/material/styles';
-import useMediaQuery from '@mui/material/useMediaQuery';
 import { GridLegacy as Grid } from '@mui/material';
 
 
@@ -14,17 +12,15 @@ interface CategoryCardProps {
 }
 
 const categories: CategoryCardProps[] = [
-  { image: '/images/under999.png', title: 'Under 999' },
-  { image: '/images/tshirts.png', title: 'T-shirts' },
-  { image: '/images/oversized.png', title: 'Oversized' },
-  { image: '/images/relaxed.png', title: 'Relaxed' },
-  { image: '/images/polo.png', title: 'Polo' },
-  { image: '/images/sweatshirts.png', title: 'Sweatshirts' },
+  { image: '/images/M-13.png', title: 'Under 999' },
+  { image: '/images/M-14.png', title: 'T-shirts' },
+  { image: '/images/M-15.png', title: 'Oversized' },
+  { image: '/images/mockup 3.png', title: 'Relaxed' },
+  { image: '/images/mockup 5.png', title: 'Polo' },
+  { image: '/images/mockup 6.png', title: 'Sweatshirts' },
 ];
 
 export default function CategoryCards() {
-  const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
   return (
     <Box sx={{ padding: { xs: 1, sm: 2, md: 3 }, mb: 4 }}>
@@ -36,8 +32,9 @@ export default function CategoryCards() {
             sm={4}
             key={idx}
             sx={{
-              height: { xs: '30vh', sm: '40vh', md: '45vh' },
               position: 'relative',
+              aspectRatio: '16/9',
+              width: '100%',
               overflow: 'hidden',
               borderRadius: 2,
             }}
@@ -53,13 +50,17 @@ export default function CategoryCards() {
                 position: 'absolute',
                 bottom: 0,
                 left: 0,
-                bgcolor: 'rgba(0,0,0,0.5)',
-                px: 1.5,
+                bgcolor: 'rgba(0,0,0,0.4)',
+                px: 1,
                 py: 0.5,
-                borderTopRightRadius: 8,
               }}
             >
-              <Typography variant="subtitle1" color="#fff" fontWeight={600}>
+              <Typography
+                variant="subtitle1"
+                color="#fff"
+                fontWeight={500}
+                sx={{ fontFamily: 'sans-serif' }}
+              >
                 {category.title}
               </Typography>
             </Box>


### PR DESCRIPTION
## Summary
- refresh CategoryCards backgrounds using new images
- simplify overlay style and enforce sans-serif font
- maintain 16:9 aspect ratio for cards

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869368031c4832f8a4e7a6c2d131bd4