### PR TITLE
Update product pages for new API data

### DIFF
--- a/src/app/components/cart/index.tsx
+++ b/src/app/components/cart/index.tsx
@@ -28,7 +28,7 @@ import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import ShoppingBagOutlinedIcon from '@mui/icons-material/ShoppingBagOutlined';
 import LocationOnOutlinedIcon from '@mui/icons-material/LocationOnOutlined';
 import PaymentOutlinedIcon from '@mui/icons-material/PaymentOutlined';
-import { Product, preProduct } from '@/app/dummyData';
+import type { Product } from '@/types';
 
 interface CartItem {
     id: number;
@@ -36,7 +36,6 @@ interface CartItem {
     subtitle: string;
     img: string;
     price: number;
-    size: string;
     qty: number;
 }
 
@@ -111,36 +110,30 @@ export default function CartPage({ buyNowProductId }: { buyNowProductId?: string
                                 id: data.product.id,
                                 title: data.product.title,
                                 subtitle: data.product.subtitle,
-                                img: data.product.image,
-                                price: data.product.price,
-                                size: data.product.size,
+                                img: data.product.images[0],
+                                price: data.product.price_after,
                                 qty: data.quantity,
                             }]);
                         } else {
                             // Product not in cart, add it with quantity 1
-                            const product = preProduct.find(p => p.id === Number(buyNowProductId));
-                            if (product) {
-                                // Add product to cart with quantity 1 using buyNow parameter
-                                await fetch('/api/cart?buyNow=true', {
-                                    method: 'POST',
-                                    headers: { ...headers, 'Content-Type': 'application/json' },
-                                    body: JSON.stringify({ product_id: product.id, quantity: 1 })
-                                });
-                                
-                                // Now fetch the cart item
-                                const cartRes = await fetch(`/api/cart?productId=${buyNowProductId}`, { headers });
-                                const cartData = await cartRes.json();
-                                if (cartData) {
-                                    setCart([{
-                                        id: cartData.product.id,
-                                        title: cartData.product.title,
-                                        subtitle: cartData.product.subtitle,
-                                        img: cartData.product.image,
-                                        price: cartData.product.price,
-                                        size: cartData.product.size,
-                                        qty: cartData.quantity,
-                                    }]);
-                                }
+                            await fetch('/api/cart?buyNow=true', {
+                                method: 'POST',
+                                headers: { ...headers, 'Content-Type': 'application/json' },
+                                body: JSON.stringify({ product_id: Number(buyNowProductId), quantity: 1 })
+                            });
+
+                            // Now fetch the cart item
+                            const cartRes = await fetch(`/api/cart?productId=${buyNowProductId}`, { headers });
+                            const cartData = await cartRes.json();
+                            if (cartData) {
+                                setCart([{
+                                    id: cartData.product.id,
+                                    title: cartData.product.title,
+                                    subtitle: cartData.product.subtitle,
+                                    img: cartData.product.images[0],
+                                    price: cartData.product.price_after,
+                                    qty: cartData.quantity,
+                                }]);
                             }
                         }
                     });
@@ -152,9 +145,8 @@ export default function CartPage({ buyNowProductId }: { buyNowProductId?: string
                         id: item.product.id,
                         title: item.product.title,
                         subtitle: item.product.subtitle,
-                        img: item.product.image,
-                        price: item.product.price,
-                        size: item.product.size,
+                        img: item.product.images[0],
+                        price: item.product.price_after,
                         qty: item.quantity,
                     }))))
             }
@@ -430,7 +422,7 @@ export default function CartPage({ buyNowProductId }: { buyNowProductId?: string
                                                             color="text.secondary"
                                                             sx={{ fontFamily: 'sans-serif' }}
                                                         >
-                                                            Size: {item.size} | Qty: {item.qty}
+                                                            Qty: {item.qty}
                                                         </Typography>
                                                     </Box>
                                                     <IconButton

--- a/src/app/components/cartDrawer/index.tsx
+++ b/src/app/components/cartDrawer/index.tsx
@@ -9,7 +9,7 @@ import RemoveIcon from '@mui/icons-material/Remove'
 import { supabase } from '@/lib/supabaseClient'
 import { useAuth } from '../AuthProvider'
 import { useRouter } from 'next/navigation'
-import { Product } from '@/app/dummyData'
+import type { Product } from '@/types'
 
 interface CartItem {
   id: number
@@ -17,7 +17,6 @@ interface CartItem {
   subtitle: string
   img: string
   price: number
-  size: string
   qty: number
 }
 
@@ -44,9 +43,8 @@ export default function CartDrawer({ open, onClose }:{ open:boolean; onClose:()=
           id: item.product.id,
           title: item.product.title,
           subtitle: item.product.subtitle,
-          img: item.product.image,
-          price: item.product.price,
-          size: item.product.size,
+          img: item.product.images[0],
+          price: item.product.price_after,
           qty: item.quantity,
         }))))
     })
@@ -109,7 +107,6 @@ export default function CartDrawer({ open, onClose }:{ open:boolean; onClose:()=
               <Box sx={{ flex: 1, minWidth: 0 }}>
                 <Typography variant="subtitle2" sx={{ fontWeight: 600, fontFamily: 'sans-serif' }}>{item.title}</Typography>
                 <Typography variant="body2" color="text.secondary" sx={{ fontFamily: 'sans-serif' }}>{item.subtitle}</Typography>
-                <Typography variant="body2" color="text.secondary" sx={{ fontFamily: 'sans-serif' }}>Size: {item.size}</Typography>
                 <Box sx={{ display: 'flex', alignItems: 'center', mt: 1 }}>
                   <IconButton size="small" onClick={() => handleDecrease(item.id)}><RemoveIcon fontSize="inherit" /></IconButton>
                   <Typography sx={{ mx: 0.5, fontFamily: 'sans-serif' }}>{item.qty}</Typography>

--- a/src/app/components/productCard/index.tsx
+++ b/src/app/components/productCard/index.tsx
@@ -10,14 +10,7 @@ import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { supabase } from '@/lib/supabaseClient';
 import { useAuth } from '../AuthProvider';
-
-export interface Product {
-  id: number;
-  title: string;
-  subtitle: string;
-  price: number;
-  images?: string[];
-}
+import type { Product } from '@/types';
 
 export const ProductCard: React.FC<{
   product: Product;
@@ -212,7 +205,7 @@ export const ProductCard: React.FC<{
             fontSize: { xs: '0.9rem', sm: '1rem' }
           }}
         >
-          ₹{product.price}
+          ₹{product.price_after}
           <Typography
           variant="body2"
           fontWeight={400}
@@ -225,7 +218,7 @@ export const ProductCard: React.FC<{
             ml: 1,
           }}
         >
-            ₹{product.price + 200}
+            ₹{product.price_before ?? product.price_after}
         </Typography>
         </Typography>
         {/* Actions */}

--- a/src/app/components/wishList/index.tsx
+++ b/src/app/components/wishList/index.tsx
@@ -3,7 +3,8 @@
 import { useEffect, useState } from 'react';
 import {  Typography, Container } from '@mui/material';
 import { supabase } from '@/lib/supabaseClient';
-import { ProductCard, Product } from '../productCard';
+import { ProductCard } from '../productCard';
+import type { Product } from '@/types';
 import { GridLegacy as Grid } from '@mui/material';
 
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,7 +10,7 @@ import { GridLegacy as Grid } from '@mui/material';
 import { ProductCard } from './components/productCard';
 import { useAuth } from './components/AuthProvider';
 import { supabase } from '@/lib/supabaseClient';
-import { Product } from './dummyData';
+import type { Product } from '@/types';
 import CategoryCards from './components/categoryCards';
 
 // Define types for API responses

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,22 @@
+export interface Product {
+  id: number;
+  title: string;
+  subtitle: string;
+  description: string | null;
+  price_before: number | null;
+  price_after: number;
+  discount_percentage: number | null;
+  category: string;
+  collection: string[];
+  material: string | null;
+  images: string[];
+  size_chart_image: string | null;
+  available_sizes: string[];
+  available_colors: string[];
+  wash_care: string | null;
+  stock_quantity: number | null;
+  is_active: boolean | null;
+  slug: string | null;
+  created_at: string | null;
+  updated_at: string | null;
+}


### PR DESCRIPTION
## Summary
- add new `Product` type describing API format
- update product card to show `price_after` and `price_before`
- fetch single product in preCheckout from `/api/products`
- filter catalogue by `category` and `collection`
- align imports with new type system
- update cart components to show prices from the API

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686be73d8704832f8c8ddd10f5844e40