### PR TITLE
Switch to Futura font

### DIFF
--- a/public/images/logo.svg
+++ b/public/images/logo.svg
@@ -24,7 +24,7 @@
 
     .stroke { stroke:#fff; }
     .fill   { fill:#fff; }
-    .mark   { fill:#fff; font-family:sans-serif; letter-spacing:8px; }
+    .mark   { fill:#fff; font-family:Futura, sans-serif; letter-spacing:8px; }
   </style>
 
   <!-- ------------- Icon block ------------- -->
@@ -34,7 +34,7 @@
 
     <!-- 😉 -->
     <g class="face face-1">
-      <text x="35" y="55" font-size="28" class="fill" font-family="sans-serif">&gt;</text>
+      <text x="35" y="55" font-size="28" class="fill" font-family="Futura, sans-serif">&gt;</text>
       <circle cx="90" cy="50" r="6" class="fill"/>
       <path d="M36 96 Q60 116 84 96" class="stroke" stroke-width="6" fill="none"/>
     </g>

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -11,15 +11,15 @@ const About = () => {
         </Box>
         <Box flex={1} display="flex" alignItems="center" justifyContent="center" sx={{ bgcolor: '#fff', width: '100%' }}>
           <Box maxWidth={600} px={{ xs: 2, md: 4 }} py={{ xs: 3, md: 0 }}>
-            <Typography variant="h3" fontWeight={400} mb={3} fontSize={{ xs: '2rem', md: '3rem' }} fontFamily="sans-serif">ABOUT US</Typography>
-            <Typography fontSize={{ xs: '1rem', md: '1.3rem' }} lineHeight={1.7} mb={4} color="#222" fontFamily="sans-serif">
+            <Typography variant="h3" fontWeight={400} mb={3} fontSize={{ xs: '2rem', md: '3rem' }} fontFamily="Futura, sans-serif">ABOUT US</Typography>
+            <Typography fontSize={{ xs: '1rem', md: '1.3rem' }} lineHeight={1.7} mb={4} color="#222" fontFamily="Futura, sans-serif">
               <strong>Minicon – Where Minimalism Meets Streetwear Aesthetic</strong>
             </Typography>
-            <Typography fontSize={{ xs: '1rem', md: '1.3rem' }} lineHeight={1.7} mb={4} color="#222" fontFamily="sans-serif">
+            <Typography fontSize={{ xs: '1rem', md: '1.3rem' }} lineHeight={1.7} mb={4} color="#222" fontFamily="Futura, sans-serif">
               Minicon is more than a clothing brand—it&apos;s a curated lifestyle. A community that values authentic expression, sustainable fashion, and understated elegance. In every thread, we embed the spirit of modern rebellion with minimalist flair. So, whether you&apos;re searching for versatile streetwear for everyday wear, or building your capsule wardrobe, Minicon invites you to explore a space where simplicity becomes statement.
             </Typography>
             <Link href="/" passHref legacyBehavior>
-              <Button variant="contained" sx={{ background: '#111', color: '#fff', fontSize: { xs: '1rem', md: '1.1rem' }, borderRadius: 2, fontWeight: 500, letterSpacing: 1, px: 4, py: 2, mb: 3, textTransform: 'none', fontFamily: 'sans-serif', '&:hover': { background: '#222' } }}>
+              <Button variant="contained" sx={{ background: '#111', color: '#fff', fontSize: { xs: '1rem', md: '1.1rem' }, borderRadius: 2, fontWeight: 500, letterSpacing: 1, px: 4, py: 2, mb: 3, textTransform: 'none', fontFamily: 'Futura, sans-serif', '&:hover': { background: '#222' } }}>
                 Shop Now
               </Button>
             </Link>

--- a/src/app/cancelRefund/page.tsx
+++ b/src/app/cancelRefund/page.tsx
@@ -83,7 +83,7 @@ export default function CancelRefundPage() {
               fontWeight: 700,
               mb: 3,
               color: '#000',
-              fontFamily: 'sans-serif'
+              fontFamily: 'Futura, sans-serif'
             }}
           >
             CANCEL & REFUND – FREQUENTLY ASKED QUESTIONS (FAQS)
@@ -94,7 +94,7 @@ export default function CancelRefundPage() {
               fontSize: { xs: '1rem', md: '1.125rem' },
               lineHeight: 1.8,
               color: '#000',
-              fontFamily: 'sans-serif'
+              fontFamily: 'Futura, sans-serif'
             }}
           >
             Everything you need to know about cancelling orders and requesting refunds.
@@ -136,7 +136,7 @@ export default function CancelRefundPage() {
                     fontWeight: 600, 
                     fontSize: '1.125rem',
                     color: '#000',
-                    fontFamily: 'sans-serif'
+                    fontFamily: 'Futura, sans-serif'
                   }}
                 >
                   🔻 {item.question}
@@ -147,7 +147,7 @@ export default function CancelRefundPage() {
                   fontSize: '1rem', 
                   lineHeight: 1.8, 
                   color: '#000', 
-                  fontFamily: 'sans-serif',
+                  fontFamily: 'Futura, sans-serif',
                   whiteSpace: 'pre-line'
                 }}>
                   {item.answer}
@@ -174,7 +174,7 @@ export default function CancelRefundPage() {
               fontWeight: 700,
               mb: 3,
               color: '#000',
-              fontFamily: 'sans-serif'
+              fontFamily: 'Futura, sans-serif'
             }}
           >
             ❓ Still Need Help?
@@ -186,7 +186,7 @@ export default function CancelRefundPage() {
               lineHeight: 1.8,
               mb: 3,
               color: '#000',
-              fontFamily: 'sans-serif'
+              fontFamily: 'Futura, sans-serif'
             }}
           >
             We&apos;re always here to help.
@@ -197,7 +197,7 @@ export default function CancelRefundPage() {
               fontSize: '1rem',
               lineHeight: 1.8,
               color: '#000',
-              fontFamily: 'sans-serif'
+              fontFamily: 'Futura, sans-serif'
             }}
           >
             📩 Email us at: miniconclothing@gmail.com
@@ -211,7 +211,7 @@ export default function CancelRefundPage() {
             mb: 2, 
             color: '#000',
             fontSize: '1.125rem',
-            fontFamily: 'sans-serif'
+            fontFamily: 'Futura, sans-serif'
           }}>
             ⚠️ Important Notes:
           </Typography>
@@ -220,7 +220,7 @@ export default function CancelRefundPage() {
               lineHeight: 1.8,
               fontSize: '1rem',
               color: '#000',
-              fontFamily: 'sans-serif',
+              fontFamily: 'Futura, sans-serif',
               mb: 1
             }}>
               All cancellation requests must be made within 12 hours of order placement
@@ -229,7 +229,7 @@ export default function CancelRefundPage() {
               lineHeight: 1.8,
               fontSize: '1rem',
               color: '#000',
-              fontFamily: 'sans-serif',
+              fontFamily: 'Futura, sans-serif',
               mb: 1
             }}>
               Unboxing videos and clear images are mandatory for refund claims
@@ -238,7 +238,7 @@ export default function CancelRefundPage() {
               lineHeight: 1.8,
               fontSize: '1rem',
               color: '#000',
-              fontFamily: 'sans-serif',
+              fontFamily: 'Futura, sans-serif',
               mb: 1
             }}>
               Refund processing takes 5-7 business days
@@ -247,7 +247,7 @@ export default function CancelRefundPage() {
               lineHeight: 1.8,
               fontSize: '1rem',
               color: '#000',
-              fontFamily: 'sans-serif'
+              fontFamily: 'Futura, sans-serif'
             }}>
               Return processing fees apply for non-defective returns
             </Typography>

--- a/src/app/categories/[[...cat]]/page.tsx
+++ b/src/app/categories/[[...cat]]/page.tsx
@@ -227,7 +227,7 @@ export default function CataloguePage() {
     <Box sx={{ width: { xs: '100%', sm: 260 }, p: 2, overflowX: 'hidden' }}>
     
       {/* Category filter */}
-      <Typography color='black' variant="subtitle1" fontWeight={700} mb={1} sx={{ fontFamily: 'sans-serif' }}>
+      <Typography color='black' variant="subtitle1" fontWeight={700} mb={1} sx={{ fontFamily: 'Futura, sans-serif' }}>
         CATEGORIES
       </Typography>
 
@@ -243,7 +243,7 @@ export default function CataloguePage() {
                   onChange={(e) => handleCategoryChange(c, e.target.checked)}
                 />
               }
-              label={<Typography variant="body2" style={{color:'black',fontFamily: 'sans-serif'}}>{c}</Typography>}
+              label={<Typography variant="body2" style={{color:'black',fontFamily: 'Futura, sans-serif'}}>{c}</Typography>}
             />
           </ListItem>
         ))}
@@ -252,7 +252,7 @@ export default function CataloguePage() {
       <Divider sx={{ my: 2, color: 'black' }} />
 
       {/* Size filter */}
-      <Typography color='black' variant="subtitle1" fontWeight={700} mb={1} sx={{ fontFamily: 'sans-serif' }}>
+      <Typography color='black' variant="subtitle1" fontWeight={700} mb={1} sx={{ fontFamily: 'Futura, sans-serif' }}>
         SIZE
       </Typography>
       <Box sx={{ 
@@ -278,7 +278,7 @@ export default function CataloguePage() {
               '&:hover': { 
                 backgroundColor: selectedSizes.has(s) ? '#333' : '#f5f5f5' 
               },
-              fontFamily: 'sans-serif',
+              fontFamily: 'Futura, sans-serif',
               textTransform: 'none',
               minWidth: 'auto',
               flexShrink: 0
@@ -292,7 +292,7 @@ export default function CataloguePage() {
       <Divider sx={{ my: 2, color: 'black' }} />
 
       {/* Color filter */}
-      <Typography color='black' variant="subtitle1" fontWeight={700} mb={1} sx={{ fontFamily: 'sans-serif' }}>
+      <Typography color='black' variant="subtitle1" fontWeight={700} mb={1} sx={{ fontFamily: 'Futura, sans-serif' }}>
         COLORS
       </Typography>
       <Box sx={{ 
@@ -318,7 +318,7 @@ export default function CataloguePage() {
               '&:hover': { 
                 backgroundColor: selectedColors.has(color) ? '#333' : '#f5f5f5' 
               },
-              fontFamily: 'sans-serif',
+              fontFamily: 'Futura, sans-serif',
               textTransform: 'none',
               minWidth: 'auto',
               flexShrink: 0
@@ -343,7 +343,7 @@ export default function CataloguePage() {
               color: 'black',
               backgroundColor: '#fff',
               '&:hover': { backgroundColor: '#f5f5f5' },
-              fontFamily: 'sans-serif',
+              fontFamily: 'Futura, sans-serif',
               textTransform: 'none'
             }}
           >
@@ -359,7 +359,7 @@ export default function CataloguePage() {
   const mobileSortDrawer = (
     <Box sx={{ p: 3 }}>
       <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 3 }}>
-        <Typography variant="h6" fontWeight={600} sx={{ fontFamily: 'sans-serif', color: 'black' }}>
+        <Typography variant="h6" fontWeight={600} sx={{ fontFamily: 'Futura, sans-serif', color: 'black' }}>
           Sort Products
         </Typography>
         <IconButton onClick={() => setSortDrawerOpen(false)}>
@@ -384,7 +384,7 @@ export default function CataloguePage() {
             <ListItemText
               primary={
                 <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                  <Typography variant="body1" sx={{ fontFamily: 'sans-serif', fontWeight: sortOpt === '' ? 600 : 400 }}>
+                  <Typography variant="body1" sx={{ fontFamily: 'Futura, sans-serif', fontWeight: sortOpt === '' ? 600 : 400 }}>
                     Sort by
                   </Typography>
                   {sortOpt === '' && <Chip label="Default" size="small" sx={{ fontSize: 10, height: 20 }} />}
@@ -411,7 +411,7 @@ export default function CataloguePage() {
               <ListItemText
                 primary={
                   <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                    <Typography variant="body1" sx={{ fontFamily: 'sans-serif', fontWeight: sortOpt === option.value ? 600 : 400 }}>
+                    <Typography variant="body1" sx={{ fontFamily: 'Futura, sans-serif', fontWeight: sortOpt === option.value ? 600 : 400 }}>
                       {option.label}
                     </Typography>
                     {sortOpt === option.value && <Chip label="Selected" size="small" sx={{ fontSize: 10, height: 20 }} />}
@@ -448,7 +448,7 @@ export default function CataloguePage() {
           >
             <FilterListIcon />
           </IconButton>
-          <Typography color='black' variant="h6" fontWeight={600} sx={{ fontFamily: 'sans-serif' }}>
+          <Typography color='black' variant="h6" fontWeight={600} sx={{ fontFamily: 'Futura, sans-serif' }}>
             {heading} — {products.length} items
           </Typography>
         </Box>
@@ -497,7 +497,7 @@ export default function CataloguePage() {
               mb: 2,
             }}
           >
-            <Typography color='black' variant="h6" fontWeight={600} sx={{ fontFamily: 'sans-serif' }}>
+            <Typography color='black' variant="h6" fontWeight={600} sx={{ fontFamily: 'Futura, sans-serif' }}>
               {heading} — {products.length} items
             </Typography>
 
@@ -525,7 +525,7 @@ export default function CataloguePage() {
                   minWidth: 200,
                   color: 'black',
                   backgroundColor: 'transparent',
-                  fontFamily: 'sans-serif',
+                  fontFamily: 'Futura, sans-serif',
                   fontWeight: 500,
                   '& .MuiSelect-select': {
                     py: 1.5,
@@ -560,7 +560,7 @@ export default function CataloguePage() {
                   sx={{
                     py: 1.5,
                     px: 2,
-                    fontFamily: 'sans-serif',
+                    fontFamily: 'Futura, sans-serif',
                     '&.Mui-selected': {
                       backgroundColor: '#f8f8f8',
                       fontWeight: 600,
@@ -582,7 +582,7 @@ export default function CataloguePage() {
                     sx={{
                       py: 1.5,
                       px: 2,
-                      fontFamily: 'sans-serif',
+                      fontFamily: 'Futura, sans-serif',
                       '&.Mui-selected': {
                         backgroundColor: '#f8f8f8',
                         fontWeight: 600,
@@ -629,7 +629,7 @@ export default function CataloguePage() {
                   justifyContent: 'space-between',
                   color: 'black',
                   backgroundColor: 'transparent',
-                  fontFamily: 'sans-serif',
+                  fontFamily: 'Futura, sans-serif',
                   fontWeight: 500,
                   textTransform: 'none',
                   border: 'none',

--- a/src/app/components/ThemeProvider/index.tsx
+++ b/src/app/components/ThemeProvider/index.tsx
@@ -4,7 +4,7 @@ import { ReactNode } from 'react';
 
 const theme = createTheme({
   typography: {
-    fontFamily: 'sans-serif',
+    fontFamily: 'Futura, sans-serif',
   },
   palette: {
     text: {
@@ -19,7 +19,7 @@ const theme = createTheme({
     MuiButton: {
       styleOverrides: {
         root: {
-          fontFamily: 'sans-serif',
+          fontFamily: 'Futura, sans-serif',
         },
       },
     },

--- a/src/app/components/account/address/index.tsx
+++ b/src/app/components/account/address/index.tsx
@@ -134,7 +134,7 @@ export default function AddressesSection() {
         {addresses.map((a) => (
           <Card key={a.id} variant="outlined" sx={{ 
             backgroundColor: '#fff',
-            fontFamily: 'sans-serif',
+            fontFamily: 'Futura, sans-serif',
             width: '100%'
           }}>
             <CardContent>
@@ -143,15 +143,15 @@ export default function AddressesSection() {
                 color="black" 
                 gutterBottom
                 variant={isMobile ? "subtitle1" : "h6"}
-                sx={{ fontFamily: 'sans-serif' }}
+                sx={{ fontFamily: 'Futura, sans-serif' }}
               >
                 {a.name}
               </Typography>
-              <Typography color="black" sx={{ fontFamily: 'sans-serif' }}>{a.line1}</Typography>
-              <Typography color="black" sx={{ fontFamily: 'sans-serif' }}>
+              <Typography color="black" sx={{ fontFamily: 'Futura, sans-serif' }}>{a.line1}</Typography>
+              <Typography color="black" sx={{ fontFamily: 'Futura, sans-serif' }}>
                 {a.city}, {a.state} – {a.pincode}
               </Typography>
-              <Typography color="black" sx={{ fontFamily: 'sans-serif' }}>Phone: {a.phone}</Typography>
+              <Typography color="black" sx={{ fontFamily: 'Futura, sans-serif' }}>Phone: {a.phone}</Typography>
               <Divider sx={{ my: 1 }} />
               <Stack 
                 direction={{ xs: 'column', sm: 'row' }} 
@@ -162,7 +162,7 @@ export default function AddressesSection() {
                   size="small" 
                   variant="outlined" 
                   onClick={() => handleOpen(a)}
-                  sx={{ fontFamily: 'sans-serif' }}
+                  sx={{ fontFamily: 'Futura, sans-serif' }}
                 >
                   Edit
                 </Button>
@@ -171,7 +171,7 @@ export default function AddressesSection() {
                   color="error"
                   variant="outlined"
                   onClick={() => handleDelete(a.id)}
-                  sx={{ fontFamily: 'sans-serif' }}
+                  sx={{ fontFamily: 'Futura, sans-serif' }}
                 >
                   Delete
                 </Button>
@@ -183,7 +183,7 @@ export default function AddressesSection() {
           variant="contained" 
           sx={{ 
             alignSelf: 'start',
-            fontFamily: 'sans-serif',
+            fontFamily: 'Futura, sans-serif',
             width: { xs: '100%', sm: 'auto' }
           }} 
           onClick={() => handleOpen()}
@@ -195,12 +195,12 @@ export default function AddressesSection() {
       <Dialog open={open} onClose={handleClose} fullWidth maxWidth="sm">
         <DialogTitle sx={{ 
           backgroundColor: '#fff', 
-          fontFamily: 'sans-serif',
+          fontFamily: 'Futura, sans-serif',
           fontSize: { xs: '1.1rem', sm: '1.25rem' }
         }}>
           {editId ? 'Edit Address' : 'Add New Address'}
         </DialogTitle>
-        <form style={{ backgroundColor: '#fff', fontFamily: 'sans-serif' }} onSubmit={handleSubmit}>
+        <form style={{ backgroundColor: '#fff', fontFamily: 'Futura, sans-serif' }} onSubmit={handleSubmit}>
           <DialogContent sx={{ minWidth: { xs: '100%', sm: 340 } }}>
             <Stack spacing={2}>
               <TextField
@@ -212,8 +212,8 @@ export default function AddressesSection() {
                 fullWidth
                 autoFocus
                 sx={{ 
-                  '& .MuiInputBase-root': { fontFamily: 'sans-serif' },
-                  '& .MuiInputLabel-root': { fontFamily: 'sans-serif' }
+                  '& .MuiInputBase-root': { fontFamily: 'Futura, sans-serif' },
+                  '& .MuiInputLabel-root': { fontFamily: 'Futura, sans-serif' }
                 }}
               />
               <TextField
@@ -224,8 +224,8 @@ export default function AddressesSection() {
                 required
                 fullWidth
                 sx={{ 
-                  '& .MuiInputBase-root': { fontFamily: 'sans-serif' },
-                  '& .MuiInputLabel-root': { fontFamily: 'sans-serif' }
+                  '& .MuiInputBase-root': { fontFamily: 'Futura, sans-serif' },
+                  '& .MuiInputLabel-root': { fontFamily: 'Futura, sans-serif' }
                 }}
               />
               <TextField
@@ -236,8 +236,8 @@ export default function AddressesSection() {
                 required
                 fullWidth
                 sx={{ 
-                  '& .MuiInputBase-root': { fontFamily: 'sans-serif' },
-                  '& .MuiInputLabel-root': { fontFamily: 'sans-serif' }
+                  '& .MuiInputBase-root': { fontFamily: 'Futura, sans-serif' },
+                  '& .MuiInputLabel-root': { fontFamily: 'Futura, sans-serif' }
                 }}
               />
               <TextField
@@ -248,8 +248,8 @@ export default function AddressesSection() {
                 required
                 fullWidth
                 sx={{ 
-                  '& .MuiInputBase-root': { fontFamily: 'sans-serif' },
-                  '& .MuiInputLabel-root': { fontFamily: 'sans-serif' }
+                  '& .MuiInputBase-root': { fontFamily: 'Futura, sans-serif' },
+                  '& .MuiInputLabel-root': { fontFamily: 'Futura, sans-serif' }
                 }}
               />
               <TextField
@@ -260,8 +260,8 @@ export default function AddressesSection() {
                 required
                 fullWidth
                 sx={{ 
-                  '& .MuiInputBase-root': { fontFamily: 'sans-serif' },
-                  '& .MuiInputLabel-root': { fontFamily: 'sans-serif' }
+                  '& .MuiInputBase-root': { fontFamily: 'Futura, sans-serif' },
+                  '& .MuiInputLabel-root': { fontFamily: 'Futura, sans-serif' }
                 }}
               />
               <TextField
@@ -272,8 +272,8 @@ export default function AddressesSection() {
                 required
                 fullWidth
                 sx={{ 
-                  '& .MuiInputBase-root': { fontFamily: 'sans-serif' },
-                  '& .MuiInputLabel-root': { fontFamily: 'sans-serif' }
+                  '& .MuiInputBase-root': { fontFamily: 'Futura, sans-serif' },
+                  '& .MuiInputLabel-root': { fontFamily: 'Futura, sans-serif' }
                 }}
               />
             </Stack>
@@ -282,14 +282,14 @@ export default function AddressesSection() {
             <Button 
               onClick={handleClose} 
               color="inherit"
-              sx={{ fontFamily: 'sans-serif' }}
+              sx={{ fontFamily: 'Futura, sans-serif' }}
             >
               Cancel
             </Button>
             <Button 
               type="submit" 
               variant="contained"
-              sx={{ fontFamily: 'sans-serif' }}
+              sx={{ fontFamily: 'Futura, sans-serif' }}
             >
               {editId ? 'Update' : 'Add'}
             </Button>

--- a/src/app/components/account/index.tsx
+++ b/src/app/components/account/index.tsx
@@ -53,14 +53,14 @@ export default function AccountPage() {
       py: { xs: 2, sm: 3, md: 4 }, 
       backgroundColor: '#fff', 
       minHeight: '100vh',
-      fontFamily: 'sans-serif'
+      fontFamily: 'Futura, sans-serif'
     }}>
       <Typography 
         color='black' 
         variant={isMobile ? "h5" : "h4"} 
         fontWeight={700} 
         mb={3}
-        sx={{ fontFamily: 'sans-serif' }}
+        sx={{ fontFamily: 'Futura, sans-serif' }}
       >
         My Account
       </Typography>
@@ -76,7 +76,7 @@ export default function AccountPage() {
           mb: 3,
           color: 'black',
           '& .MuiTab-root': {
-            fontFamily: 'sans-serif',
+            fontFamily: 'Futura, sans-serif',
             fontSize: { xs: '0.875rem', sm: '1rem' },
             minWidth: { xs: 'auto', sm: '120px' },
             padding: { xs: '12px 8px', sm: '12px 16px' }

--- a/src/app/components/account/orders/index.tsx
+++ b/src/app/components/account/orders/index.tsx
@@ -25,13 +25,13 @@ export default function OrdersSection() {
   return (
     <>
       {MOCK_ORDERS.length === 0 ? (
-        <Typography sx={{ fontFamily: 'sans-serif' }}>No past orders.</Typography>
+        <Typography sx={{ fontFamily: 'Futura, sans-serif' }}>No past orders.</Typography>
       ) : (
         <Stack spacing={2}>
           {MOCK_ORDERS.map((o) => (
             <Card key={o.id} variant="outlined" sx={{ 
               backgroundColor: '#fff',
-              fontFamily: 'sans-serif',
+              fontFamily: 'Futura, sans-serif',
               width: '100%'
             }}>
               <CardContent>
@@ -50,14 +50,14 @@ export default function OrdersSection() {
                       fontWeight={600} 
                       color="black"
                       variant={isMobile ? "subtitle1" : "h6"}
-                      sx={{ fontFamily: 'sans-serif' }}
+                      sx={{ fontFamily: 'Futura, sans-serif' }}
                     >
                       {o.id}
                     </Typography>
                     <Typography 
                       variant="body2" 
                       color="black"
-                      sx={{ fontFamily: 'sans-serif' }}
+                      sx={{ fontFamily: 'Futura, sans-serif' }}
                     >
                       {o.date}
                     </Typography>
@@ -65,7 +65,7 @@ export default function OrdersSection() {
                   <Box>
                     <Typography 
                       color="black"
-                      sx={{ fontFamily: 'sans-serif' }}
+                      sx={{ fontFamily: 'Futura, sans-serif' }}
                     >
                       {o.items} item{o.items > 1 ? 's' : ''}
                     </Typography>
@@ -74,7 +74,7 @@ export default function OrdersSection() {
                     <Typography 
                       fontWeight={700} 
                       color="black"
-                      sx={{ fontFamily: 'sans-serif' }}
+                      sx={{ fontFamily: 'Futura, sans-serif' }}
                     >
                       ₹ {o.total}
                     </Typography>
@@ -82,7 +82,7 @@ export default function OrdersSection() {
                   <Box>
                     <Typography 
                       color="black"
-                      sx={{ fontFamily: 'sans-serif' }}
+                      sx={{ fontFamily: 'Futura, sans-serif' }}
                     >
                       {o.status}
                     </Typography>
@@ -93,7 +93,7 @@ export default function OrdersSection() {
                       size="small" 
                       variant="outlined"
                       sx={{ 
-                        fontFamily: 'sans-serif',
+                        fontFamily: 'Futura, sans-serif',
                         mt: { xs: 1, sm: 0 }
                       }}
                     >

--- a/src/app/components/account/profile/index.tsx
+++ b/src/app/components/account/profile/index.tsx
@@ -84,7 +84,7 @@ export default function ProfileSection() {
       <Card variant="outlined" sx={{ 
         maxWidth: 600, 
         backgroundColor: '#fff',
-        fontFamily: 'sans-serif',
+        fontFamily: 'Futura, sans-serif',
         width: '100%'
       }}>
         <CardContent>
@@ -93,20 +93,20 @@ export default function ProfileSection() {
             variant={isMobile ? "subtitle1" : "h6"} 
             fontWeight={600} 
             gutterBottom
-            sx={{ fontFamily: 'sans-serif' }}
+            sx={{ fontFamily: 'Futura, sans-serif' }}
           >
             Personal Information
           </Typography>
           <Stack spacing={1}>
-            <Typography color="black" sx={{ fontFamily: 'sans-serif' }}>Name: {profile?.name || ''}</Typography>
-            <Typography color="black" sx={{ fontFamily: 'sans-serif' }}>Email: {profile?.email || ''}</Typography>
-            <Typography color="black" sx={{ fontFamily: 'sans-serif' }}>Phone: {profile?.phone || ''}</Typography>
+            <Typography color="black" sx={{ fontFamily: 'Futura, sans-serif' }}>Name: {profile?.name || ''}</Typography>
+            <Typography color="black" sx={{ fontFamily: 'Futura, sans-serif' }}>Email: {profile?.email || ''}</Typography>
+            <Typography color="black" sx={{ fontFamily: 'Futura, sans-serif' }}>Phone: {profile?.phone || ''}</Typography>
           </Stack>
           <Button 
             variant="contained" 
             sx={{ 
               mt: 2,
-              fontFamily: 'sans-serif',
+              fontFamily: 'Futura, sans-serif',
               width: { xs: '100%', sm: 'auto' }
             }} 
             onClick={handleOpen}
@@ -118,7 +118,7 @@ export default function ProfileSection() {
 
       {/* Edit Profile Modal */}
       <Dialog open={open} onClose={handleClose} fullWidth maxWidth="sm">
-        <form style={{ backgroundColor: '#fff', fontFamily: 'sans-serif' }} onSubmit={handleSubmit}>
+        <form style={{ backgroundColor: '#fff', fontFamily: 'Futura, sans-serif' }} onSubmit={handleSubmit}>
           <DialogContent sx={{ minWidth: { xs: '100%', sm: 340 } }}>
             <Stack spacing={2}>
               <TextField
@@ -130,8 +130,8 @@ export default function ProfileSection() {
                 autoFocus
                 required
                 sx={{ 
-                  '& .MuiInputBase-root': { fontFamily: 'sans-serif' },
-                  '& .MuiInputLabel-root': { fontFamily: 'sans-serif' }
+                  '& .MuiInputBase-root': { fontFamily: 'Futura, sans-serif' },
+                  '& .MuiInputLabel-root': { fontFamily: 'Futura, sans-serif' }
                 }}
               />
               <TextField
@@ -143,8 +143,8 @@ export default function ProfileSection() {
                 onChange={handleChange}
                 required
                 sx={{ 
-                  '& .MuiInputBase-root': { fontFamily: 'sans-serif' },
-                  '& .MuiInputLabel-root': { fontFamily: 'sans-serif' }
+                  '& .MuiInputBase-root': { fontFamily: 'Futura, sans-serif' },
+                  '& .MuiInputLabel-root': { fontFamily: 'Futura, sans-serif' }
                 }}
               />
               <TextField
@@ -155,8 +155,8 @@ export default function ProfileSection() {
                 onChange={handleChange}
                 required
                 sx={{ 
-                  '& .MuiInputBase-root': { fontFamily: 'sans-serif' },
-                  '& .MuiInputLabel-root': { fontFamily: 'sans-serif' }
+                  '& .MuiInputBase-root': { fontFamily: 'Futura, sans-serif' },
+                  '& .MuiInputLabel-root': { fontFamily: 'Futura, sans-serif' }
                 }}
               />
             </Stack>
@@ -165,14 +165,14 @@ export default function ProfileSection() {
             <Button 
               onClick={handleClose} 
               color="inherit"
-              sx={{ fontFamily: 'sans-serif' }}
+              sx={{ fontFamily: 'Futura, sans-serif' }}
             >
               Cancel
             </Button>
             <Button 
               type="submit" 
               variant="contained"
-              sx={{ fontFamily: 'sans-serif' }}
+              sx={{ fontFamily: 'Futura, sans-serif' }}
             >
               Save
             </Button>

--- a/src/app/components/cart/index.tsx
+++ b/src/app/components/cart/index.tsx
@@ -250,7 +250,7 @@ export default function CartPage({ buyNowProductId }: { buyNowProductId?: string
                 flexDirection: 'column',
                 minHeight: '100vh',
                 bgcolor: '#f8f9fa',
-                fontFamily: 'sans-serif',
+                fontFamily: 'Futura, sans-serif',
             }}
         >
             {/* 2. MAIN CONTENT GROWS - px: 0 ensures no double padding */}
@@ -272,7 +272,7 @@ export default function CartPage({ buyNowProductId }: { buyNowProductId?: string
                         mb: { xs: 2, md: 4, lg: 4 },
                         color: '#1a1a1a',
                         fontSize: { xs: '1.5rem', md: '2rem', lg: '2rem' },
-                        fontFamily: 'sans-serif',
+                        fontFamily: 'Futura, sans-serif',
                         wordBreak: 'break-word',
                     }}
                 >
@@ -304,7 +304,7 @@ export default function CartPage({ buyNowProductId }: { buyNowProductId?: string
                                 }}
                             >
                                 <ShoppingBagOutlinedIcon sx={{ fontSize: 48, color: '#ccc', mb: 2 }} />
-                                <Typography variant="h6" color="text.secondary" gutterBottom sx={{ fontFamily: 'sans-serif' }}>
+                                <Typography variant="h6" color="text.secondary" gutterBottom sx={{ fontFamily: 'Futura, sans-serif' }}>
                                     Your cart is empty
                                 </Typography>
                                 <Button
@@ -339,7 +339,7 @@ export default function CartPage({ buyNowProductId }: { buyNowProductId?: string
                                             mb: 2,
                                             color: '#1a1a1a',
                                             fontWeight: 600,
-                                            fontFamily: 'sans-serif'
+                                            fontFamily: 'Futura, sans-serif'
                                         }}
                                     >
                                         {buyNowProductId ? 'Product' : `Cart Items (${cart.length})`}
@@ -405,7 +405,7 @@ export default function CartPage({ buyNowProductId }: { buyNowProductId?: string
                                                                 fontWeight: 600,
                                                                 color: '#1a1a1a',
                                                                 mb: 0.5,
-                                                                fontFamily: 'sans-serif'
+                                                                fontFamily: 'Futura, sans-serif'
                                                             }}
                                                         >
                                                             {item.title}
@@ -413,14 +413,14 @@ export default function CartPage({ buyNowProductId }: { buyNowProductId?: string
                                                         <Typography
                                                             variant="body2"
                                                             color="text.secondary"
-                                                            sx={{ mb: 0.5, fontFamily: 'sans-serif' }}
+                                                            sx={{ mb: 0.5, fontFamily: 'Futura, sans-serif' }}
                                                         >
                                                             {item.subtitle}
                                                         </Typography>
                                                         <Typography
                                                             variant="body2"
                                                             color="text.secondary"
-                                                            sx={{ fontFamily: 'sans-serif' }}
+                                                            sx={{ fontFamily: 'Futura, sans-serif' }}
                                                         >
                                                             Qty: {item.qty}
                                                         </Typography>
@@ -447,7 +447,7 @@ export default function CartPage({ buyNowProductId }: { buyNowProductId?: string
                                                         fontWeight: 600,
                                                         color: '#1a1a1a',
                                                         mt: 1,
-                                                        fontFamily: 'sans-serif'
+                                                        fontFamily: 'Futura, sans-serif'
                                                     }}
                                                 >
                                                     {formatINR(item.price * item.qty)}
@@ -475,7 +475,7 @@ export default function CartPage({ buyNowProductId }: { buyNowProductId?: string
                                             mb: 2,
                                             color: '#1a1a1a',
                                             fontWeight: 600,
-                                            fontFamily: 'sans-serif'
+                                            fontFamily: 'Futura, sans-serif'
                                         }}
                                     >
                                         Price Details
@@ -483,21 +483,21 @@ export default function CartPage({ buyNowProductId }: { buyNowProductId?: string
 
                                     <Stack spacing={1.5}>
                                         <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
-                                            <Typography color="text.secondary" sx={{ fontFamily: 'sans-serif' }}>Subtotal</Typography>
-                                            <Typography sx={{ fontFamily: 'sans-serif' }}>{formatINR(subtotal)}</Typography>
+                                            <Typography color="text.secondary" sx={{ fontFamily: 'Futura, sans-serif' }}>Subtotal</Typography>
+                                            <Typography sx={{ fontFamily: 'Futura, sans-serif' }}>{formatINR(subtotal)}</Typography>
                                         </Box>
                                         <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
-                                            <Typography color="text.secondary" sx={{ fontFamily: 'sans-serif' }}>Shipping</Typography>
-                                            <Typography sx={{ fontFamily: 'sans-serif' }}>{shipping === 0 ? 'Free' : formatINR(shipping)}</Typography>
+                                            <Typography color="text.secondary" sx={{ fontFamily: 'Futura, sans-serif' }}>Shipping</Typography>
+                                            <Typography sx={{ fontFamily: 'Futura, sans-serif' }}>{shipping === 0 ? 'Free' : formatINR(shipping)}</Typography>
                                         </Box>
                                         <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
-                                            <Typography color="text.secondary" sx={{ fontFamily: 'sans-serif' }}>Taxes & Fees</Typography>
-                                            <Typography sx={{ fontFamily: 'sans-serif' }}>{formatINR(taxes)}</Typography>
+                                            <Typography color="text.secondary" sx={{ fontFamily: 'Futura, sans-serif' }}>Taxes & Fees</Typography>
+                                            <Typography sx={{ fontFamily: 'Futura, sans-serif' }}>{formatINR(taxes)}</Typography>
                                         </Box>
                                         <Divider sx={{ my: 1 }} />
                                         <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
-                                            <Typography variant="subtitle1" fontWeight={600} sx={{ fontFamily: 'sans-serif' }}>Total</Typography>
-                                            <Typography variant="subtitle1" fontWeight={600} sx={{ fontFamily: 'sans-serif' }}>
+                                            <Typography variant="subtitle1" fontWeight={600} sx={{ fontFamily: 'Futura, sans-serif' }}>Total</Typography>
+                                            <Typography variant="subtitle1" fontWeight={600} sx={{ fontFamily: 'Futura, sans-serif' }}>
                                                 {formatINR(total)}
                                             </Typography>
                                         </Box>
@@ -529,7 +529,7 @@ export default function CartPage({ buyNowProductId }: { buyNowProductId?: string
                                     sx={{
                                         color: '#1a1a1a',
                                         fontWeight: 600,
-                                        fontFamily: 'sans-serif'
+                                        fontFamily: 'Futura, sans-serif'
                                     }}
                                 >
                                     Delivery Address
@@ -540,7 +540,7 @@ export default function CartPage({ buyNowProductId }: { buyNowProductId?: string
                                     sx={{
                                         color: '#fe5000',
                                         '&:hover': { bgcolor: 'rgba(254, 80, 0, 0.04)' },
-                                        fontFamily: 'sans-serif'
+                                        fontFamily: 'Futura, sans-serif'
                                     }}
                                 >
                                     Add New
@@ -549,13 +549,13 @@ export default function CartPage({ buyNowProductId }: { buyNowProductId?: string
 
                             {addresses.length === 0 ? (
                                 <Box sx={{ textAlign: 'center', py: 3 }}>
-                                    <Typography color="text.secondary" sx={{ fontFamily: 'sans-serif', mb: 2 }}>
+                                    <Typography color="text.secondary" sx={{ fontFamily: 'Futura, sans-serif', mb: 2 }}>
                                         No addresses found. Add your first delivery address.
                                     </Typography>
                                     <Button
                                         variant="outlined"
                                         onClick={() => handleOpenAddressModal()}
-                                        sx={{ fontFamily: 'sans-serif' }}
+                                        sx={{ fontFamily: 'Futura, sans-serif' }}
                                     >
                                         Add Address
                                     </Button>
@@ -569,7 +569,7 @@ export default function CartPage({ buyNowProductId }: { buyNowProductId?: string
                                             sx={{ 
                                                 backgroundColor: selectedAddress === addr.id ? 'rgba(254, 80, 0, 0.04)' : '#fff',
                                                 border: selectedAddress === addr.id ? '2px solid #fe5000' : '1px solid #e0e0e0',
-                                                fontFamily: 'sans-serif',
+                                                fontFamily: 'Futura, sans-serif',
                                                 cursor: 'pointer',
                                                 '&:hover': {
                                                     borderColor: '#fe5000',
@@ -584,15 +584,15 @@ export default function CartPage({ buyNowProductId }: { buyNowProductId?: string
                                                     color="black" 
                                                     gutterBottom
                                                     variant={isMobile ? "subtitle1" : "h6"}
-                                                    sx={{ fontFamily: 'sans-serif' }}
+                                                    sx={{ fontFamily: 'Futura, sans-serif' }}
                                                 >
                                                     {addr.name}
                                                 </Typography>
-                                                <Typography color="black" sx={{ fontFamily: 'sans-serif' }}>{addr.line1}</Typography>
-                                                <Typography color="black" sx={{ fontFamily: 'sans-serif' }}>
+                                                <Typography color="black" sx={{ fontFamily: 'Futura, sans-serif' }}>{addr.line1}</Typography>
+                                                <Typography color="black" sx={{ fontFamily: 'Futura, sans-serif' }}>
                                                     {addr.city}, {addr.state} – {addr.pincode}
                                                 </Typography>
-                                                <Typography color="black" sx={{ fontFamily: 'sans-serif' }}>Phone: {addr.phone}</Typography>
+                                                <Typography color="black" sx={{ fontFamily: 'Futura, sans-serif' }}>Phone: {addr.phone}</Typography>
                                                 <Divider sx={{ my: 1 }} />
                                                 <Stack 
                                                     direction={{ xs: 'column', sm: 'row' }} 
@@ -606,7 +606,7 @@ export default function CartPage({ buyNowProductId }: { buyNowProductId?: string
                                                             e.stopPropagation();
                                                             handleOpenAddressModal(addr);
                                                         }}
-                                                        sx={{ fontFamily: 'sans-serif' }}
+                                                        sx={{ fontFamily: 'Futura, sans-serif' }}
                                                     >
                                                         Edit
                                                     </Button>
@@ -618,7 +618,7 @@ export default function CartPage({ buyNowProductId }: { buyNowProductId?: string
                                                             e.stopPropagation();
                                                             handleDeleteAddress(addr.id);
                                                         }}
-                                                        sx={{ fontFamily: 'sans-serif' }}
+                                                        sx={{ fontFamily: 'Futura, sans-serif' }}
                                                     >
                                                         Delete
                                                     </Button>
@@ -647,7 +647,7 @@ export default function CartPage({ buyNowProductId }: { buyNowProductId?: string
                                     sx={{
                                         color: '#1a1a1a',
                                         fontWeight: 600,
-                                        fontFamily: 'sans-serif'
+                                        fontFamily: 'Futura, sans-serif'
                                     }}
                                 >
                                     Payment Method
@@ -659,12 +659,12 @@ export default function CartPage({ buyNowProductId }: { buyNowProductId?: string
                                 onChange={(e) => setPaymentMode(e.target.value)}
                                 fullWidth
                                 size="small"
-                                sx={{ fontFamily: 'sans-serif' }}
+                                sx={{ fontFamily: 'Futura, sans-serif' }}
                             >
-                                <MenuItem value="card" sx={{ fontFamily: 'sans-serif' }}>Credit/Debit Card</MenuItem>
-                                <MenuItem value="upi" sx={{ fontFamily: 'sans-serif' }}>UPI</MenuItem>
-                                <MenuItem value="netbanking" sx={{ fontFamily: 'sans-serif' }}>Net Banking</MenuItem>
-                                <MenuItem value="cod" sx={{ fontFamily: 'sans-serif' }}>Cash on Delivery</MenuItem>
+                                <MenuItem value="card" sx={{ fontFamily: 'Futura, sans-serif' }}>Credit/Debit Card</MenuItem>
+                                <MenuItem value="upi" sx={{ fontFamily: 'Futura, sans-serif' }}>UPI</MenuItem>
+                                <MenuItem value="netbanking" sx={{ fontFamily: 'Futura, sans-serif' }}>Net Banking</MenuItem>
+                                <MenuItem value="cod" sx={{ fontFamily: 'Futura, sans-serif' }}>Cash on Delivery</MenuItem>
                             </Select>
                         </Paper>
 
@@ -682,7 +682,7 @@ export default function CartPage({ buyNowProductId }: { buyNowProductId?: string
                                     bgcolor: '#f5f5f5',
                                     color: '#999'
                                 },
-                                fontFamily: 'sans-serif'
+                                fontFamily: 'Futura, sans-serif'
                             }}
                         >
                             Proceed to Payment ({formatINR(total)})
@@ -701,13 +701,13 @@ export default function CartPage({ buyNowProductId }: { buyNowProductId?: string
                     sx: {
                         borderRadius: 2,
                         p: 1,
-                        fontFamily: 'sans-serif',
+                        fontFamily: 'Futura, sans-serif',
                         width: '100%',
                         boxSizing: 'border-box',
                     }
                 }}
             >
-                <DialogTitle sx={{ fontWeight: 600, fontFamily: 'sans-serif' }}>
+                <DialogTitle sx={{ fontWeight: 600, fontFamily: 'Futura, sans-serif' }}>
                     {editId ? 'Edit Address' : 'Add New Address'}
                 </DialogTitle>
                 <DialogContent>
@@ -721,10 +721,10 @@ export default function CartPage({ buyNowProductId }: { buyNowProductId?: string
                             fullWidth
                             autoFocus
                             InputProps={{
-                                sx: { fontFamily: 'sans-serif' }
+                                sx: { fontFamily: 'Futura, sans-serif' }
                             }}
                             InputLabelProps={{
-                                sx: { fontFamily: 'sans-serif' }
+                                sx: { fontFamily: 'Futura, sans-serif' }
                             }}
                         />
                         <TextField
@@ -735,10 +735,10 @@ export default function CartPage({ buyNowProductId }: { buyNowProductId?: string
                             required
                             fullWidth
                             InputProps={{
-                                sx: { fontFamily: 'sans-serif' }
+                                sx: { fontFamily: 'Futura, sans-serif' }
                             }}
                             InputLabelProps={{
-                                sx: { fontFamily: 'sans-serif' }
+                                sx: { fontFamily: 'Futura, sans-serif' }
                             }}
                         />
                         <TextField
@@ -749,10 +749,10 @@ export default function CartPage({ buyNowProductId }: { buyNowProductId?: string
                             required
                             fullWidth
                             InputProps={{
-                                sx: { fontFamily: 'sans-serif' }
+                                sx: { fontFamily: 'Futura, sans-serif' }
                             }}
                             InputLabelProps={{
-                                sx: { fontFamily: 'sans-serif' }
+                                sx: { fontFamily: 'Futura, sans-serif' }
                             }}
                         />
                         <TextField
@@ -763,10 +763,10 @@ export default function CartPage({ buyNowProductId }: { buyNowProductId?: string
                             required
                             fullWidth
                             InputProps={{
-                                sx: { fontFamily: 'sans-serif' }
+                                sx: { fontFamily: 'Futura, sans-serif' }
                             }}
                             InputLabelProps={{
-                                sx: { fontFamily: 'sans-serif' }
+                                sx: { fontFamily: 'Futura, sans-serif' }
                             }}
                         />
                         <TextField
@@ -777,10 +777,10 @@ export default function CartPage({ buyNowProductId }: { buyNowProductId?: string
                             required
                             fullWidth
                             InputProps={{
-                                sx: { fontFamily: 'sans-serif' }
+                                sx: { fontFamily: 'Futura, sans-serif' }
                             }}
                             InputLabelProps={{
-                                sx: { fontFamily: 'sans-serif' }
+                                sx: { fontFamily: 'Futura, sans-serif' }
                             }}
                         />
                         <TextField
@@ -791,10 +791,10 @@ export default function CartPage({ buyNowProductId }: { buyNowProductId?: string
                             required
                             fullWidth
                             InputProps={{
-                                sx: { fontFamily: 'sans-serif' }
+                                sx: { fontFamily: 'Futura, sans-serif' }
                             }}
                             InputLabelProps={{
-                                sx: { fontFamily: 'sans-serif' }
+                                sx: { fontFamily: 'Futura, sans-serif' }
                             }}
                         />
                     </Stack>
@@ -804,7 +804,7 @@ export default function CartPage({ buyNowProductId }: { buyNowProductId?: string
                         onClick={handleCloseAddressModal}
                         sx={{
                             color: '#666',
-                            fontFamily: 'sans-serif'
+                            fontFamily: 'Futura, sans-serif'
                         }}
                     >
                         Cancel
@@ -817,7 +817,7 @@ export default function CartPage({ buyNowProductId }: { buyNowProductId?: string
                             bgcolor: '#fe5000',
                             color: '#fff',
                             '&:hover': { bgcolor: '#d64500' },
-                            fontFamily: 'sans-serif'
+                            fontFamily: 'Futura, sans-serif'
                         }}
                     >
                         {editId ? 'Update Address' : 'Add Address'}

--- a/src/app/components/cartDrawer/index.tsx
+++ b/src/app/components/cartDrawer/index.tsx
@@ -95,7 +95,7 @@ export default function CartDrawer({ open, onClose }:{ open:boolean; onClose:()=
     <Drawer anchor="right" open={open} onClose={onClose}
       sx={{ '& .MuiDrawer-paper': { width: { xs: '80vw', sm: 380 }, maxWidth: 380 } }}>
       <Box sx={{ p: 2, display: 'flex', flexDirection: 'column', height: '100%', boxSizing: 'border-box', bgcolor: '#fff' }}>
-        <Typography variant="h6" sx={{ fontWeight: 600, mb: 2, fontFamily: 'sans-serif' }}>
+        <Typography variant="h6" sx={{ fontWeight: 600, mb: 2, fontFamily: 'Futura, sans-serif' }}>
           My Cart ({cart.length})
         </Typography>
         <Box sx={{ flex: 1, overflowY: 'auto' }}>
@@ -105,11 +105,11 @@ export default function CartDrawer({ open, onClose }:{ open:boolean; onClose:()=
                 <Image src={item.img} alt={item.title} width={80} height={80} style={{ objectFit: 'contain' }} />
               </Box>
               <Box sx={{ flex: 1, minWidth: 0 }}>
-                <Typography variant="subtitle2" sx={{ fontWeight: 600, fontFamily: 'sans-serif' }}>{item.title}</Typography>
-                <Typography variant="body2" color="text.secondary" sx={{ fontFamily: 'sans-serif' }}>{item.subtitle}</Typography>
+                <Typography variant="subtitle2" sx={{ fontWeight: 600, fontFamily: 'Futura, sans-serif' }}>{item.title}</Typography>
+                <Typography variant="body2" color="text.secondary" sx={{ fontFamily: 'Futura, sans-serif' }}>{item.subtitle}</Typography>
                 <Box sx={{ display: 'flex', alignItems: 'center', mt: 1 }}>
                   <IconButton size="small" onClick={() => handleDecrease(item.id)}><RemoveIcon fontSize="inherit" /></IconButton>
-                  <Typography sx={{ mx: 0.5, fontFamily: 'sans-serif' }}>{item.qty}</Typography>
+                  <Typography sx={{ mx: 0.5, fontFamily: 'Futura, sans-serif' }}>{item.qty}</Typography>
                   <IconButton size="small" onClick={() => handleIncrease(item.id)}><AddIcon fontSize="inherit" /></IconButton>
                   <IconButton onClick={() => handleDelete(item.id)} sx={{ ml: 'auto' }}><DeleteOutlineIcon /></IconButton>
                 </Box>
@@ -119,11 +119,11 @@ export default function CartDrawer({ open, onClose }:{ open:boolean; onClose:()=
         </Box>
         <Box>
           <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 2 }}>
-            <Typography variant="subtitle1" sx={{ fontFamily: 'sans-serif' }}>Total</Typography>
-            <Typography variant="subtitle1" sx={{ fontFamily: 'sans-serif', fontWeight: 600 }}>{formatINR(subtotal)}</Typography>
+            <Typography variant="subtitle1" sx={{ fontFamily: 'Futura, sans-serif' }}>Total</Typography>
+            <Typography variant="subtitle1" sx={{ fontFamily: 'Futura, sans-serif', fontWeight: 600 }}>{formatINR(subtotal)}</Typography>
           </Box>
           <Button variant="contained" fullWidth disabled={cart.length === 0}
-            sx={{ bgcolor: '#fe5000', '&:hover': { bgcolor: '#d64500' }, fontFamily: 'sans-serif' }}
+            sx={{ bgcolor: '#fe5000', '&:hover': { bgcolor: '#d64500' }, fontFamily: 'Futura, sans-serif' }}
             onClick={() => { router.push('/cart'); onClose(); }}>
             Proceed to Checkout
           </Button>

--- a/src/app/components/categoryCards/index.tsx
+++ b/src/app/components/categoryCards/index.tsx
@@ -76,7 +76,7 @@ export default function CategoryCards() {
                   color="#fff"
                   fontWeight={500}
                   sx={{ 
-                    fontFamily: 'sans-serif',
+                    fontFamily: 'Futura, sans-serif',
                     fontSize: { xs: '0.875rem', sm: '1rem' } // Smaller font on mobile
                   }}
                 >

--- a/src/app/components/footer/index.tsx
+++ b/src/app/components/footer/index.tsx
@@ -22,11 +22,11 @@ export default function Footer() {
             {/* Column 1: About Us & Disclaimer */}
             <Grid size={{ xs: 12, sm: 6, md: 4 }}>
               <Stack spacing={0.5}>
-                <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 1, letterSpacing: 1, fontFamily: 'sans-serif' }}>ABOUT US</Typography>
+                <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 1, letterSpacing: 1, fontFamily: 'Futura, sans-serif' }}>ABOUT US</Typography>
                 <Stack spacing={0.5}>
                  
-                  <Link href="/about" underline="hover" sx={{ color: 'inherit', fontSize: 14, fontFamily: 'sans-serif' }}>Learn More</Link>
-                  <Link href="/disclaimer" underline="hover" sx={{ color: 'inherit', fontSize: 14, fontFamily: 'sans-serif' }}>Disclaimer</Link>
+                  <Link href="/about" underline="hover" sx={{ color: 'inherit', fontSize: 14, fontFamily: 'Futura, sans-serif' }}>Learn More</Link>
+                  <Link href="/disclaimer" underline="hover" sx={{ color: 'inherit', fontSize: 14, fontFamily: 'Futura, sans-serif' }}>Disclaimer</Link>
                 </Stack>
               </Stack>
             </Grid>
@@ -34,12 +34,12 @@ export default function Footer() {
             {/* Column 2: Policies */}
             <Grid size={{ xs: 12, sm: 6, md: 4 }}>
               <Box>
-                <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 1, letterSpacing: 1, fontFamily: 'sans-serif' }}>POLICIES</Typography>
+                <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 1, letterSpacing: 1, fontFamily: 'Futura, sans-serif' }}>POLICIES</Typography>
                 <Stack spacing={0.5}>
-                  <Link href="/returnPolicy" underline="hover" sx={{ color: 'inherit', fontSize: 14, fontFamily: 'sans-serif' }}>Return Your Order</Link>
-                  <Link href="/shipping" underline="hover" sx={{ color: 'inherit', fontSize: 14, fontFamily: 'sans-serif' }}>Shipping Policy</Link>
-                  <Link href="/cancelRefund" underline="hover" sx={{ color: 'inherit', fontSize: 14, fontFamily: 'sans-serif' }}>Cancel and refund</Link>
-                  <Link href="/privacy" underline="hover" sx={{ color: 'inherit', fontSize: 14, fontFamily: 'sans-serif' }}>Privacy Policy</Link>
+                  <Link href="/returnPolicy" underline="hover" sx={{ color: 'inherit', fontSize: 14, fontFamily: 'Futura, sans-serif' }}>Return Your Order</Link>
+                  <Link href="/shipping" underline="hover" sx={{ color: 'inherit', fontSize: 14, fontFamily: 'Futura, sans-serif' }}>Shipping Policy</Link>
+                  <Link href="/cancelRefund" underline="hover" sx={{ color: 'inherit', fontSize: 14, fontFamily: 'Futura, sans-serif' }}>Cancel and refund</Link>
+                  <Link href="/privacy" underline="hover" sx={{ color: 'inherit', fontSize: 14, fontFamily: 'Futura, sans-serif' }}>Privacy Policy</Link>
                 </Stack>
               </Box>
             </Grid>

--- a/src/app/components/header/index.tsx
+++ b/src/app/components/header/index.tsx
@@ -69,7 +69,7 @@ export default function Header() {
         <div key={label}>
           <Button
             sx={{
-              fontFamily: 'sans-serif',
+              fontFamily: 'Futura, sans-serif',
               color: 'white',
               fontSize: { xs: '0.9rem', sm: '1rem' }
             }}
@@ -105,7 +105,7 @@ export default function Header() {
                   '&:hover': { bgcolor: '#222' }
                 }}
               >
-                <Typography sx={{ color: 'white', fontFamily: 'sans-serif' }}>
+                <Typography sx={{ color: 'white', fontFamily: 'Futura, sans-serif' }}>
                   {item}
                 </Typography>
               </MenuItem>
@@ -279,7 +279,7 @@ export default function Header() {
                       },
                     }}
                   >
-                    <Typography sx={{ fontFamily: 'sans-serif', fontSize: '1.1rem', color: '#000', pl: 1 }}>
+                    <Typography sx={{ fontFamily: 'Futura, sans-serif', fontSize: '1.1rem', color: '#000', pl: 1 }}>
                       {label}
                     </Typography>
                   </AccordionSummary>
@@ -299,7 +299,7 @@ export default function Header() {
                           margin: 0,
                         }}
                       >
-                        <Typography sx={{ color: '#000', fontFamily: 'sans-serif', fontSize: '1rem' }}>
+                        <Typography sx={{ color: '#000', fontFamily: 'Futura, sans-serif', fontSize: '1rem' }}>
                           {item}
                         </Typography>
                       </Box>

--- a/src/app/components/productCard/index.tsx
+++ b/src/app/components/productCard/index.tsx
@@ -154,7 +154,7 @@ export const ProductCard: React.FC<{
               fontWeight={700}
               color="black"
               sx={{
-                fontFamily: 'sans-serif',
+                fontFamily: 'Futura, sans-serif',
                 fontSize: titleFontSize,
                 whiteSpace: 'nowrap',
                 overflow: 'visible',
@@ -172,7 +172,7 @@ export const ProductCard: React.FC<{
               fontWeight={700}
               color="black"
               sx={{
-                fontFamily: 'sans-serif',
+                fontFamily: 'Futura, sans-serif',
                 fontSize: { xs: '0.92rem', sm: '1rem' },
                 whiteSpace: 'nowrap',
               }}
@@ -185,7 +185,7 @@ export const ProductCard: React.FC<{
               color="text.secondary"
               sx={{
                 textDecoration: 'line-through',
-                fontFamily: 'sans-serif',
+                fontFamily: 'Futura, sans-serif',
                 fontSize: { xs: '0.7rem', sm: '0.82rem' },
                 whiteSpace: 'nowrap',
               }}

--- a/src/app/components/wishList/index.tsx
+++ b/src/app/components/wishList/index.tsx
@@ -33,13 +33,13 @@ export default function WishlistPage() {
         fontWeight={700}
         mb={4}
         align="center"
-        fontFamily="sans-serif"
+        fontFamily="Futura, sans-serif"
       >
         Your Wishlist
       </Typography>
 
       {wishlist.length === 0 ? (
-        <Typography align="center" color="text.secondary" fontFamily="sans-serif">
+        <Typography align="center" color="text.secondary" fontFamily="Futura, sans-serif">
           Your wishlist is empty!
         </Typography>
       ) : (

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -10,78 +10,78 @@ import BusinessIcon from '@mui/icons-material/Business';
 
 export default function ContactPage() {
   return (
-    <Container maxWidth="md" sx={{ py: 6, fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif', color: 'black' }}>
-      <Typography variant="h4" component="h1" sx={{ textAlign: 'center', fontWeight: 'bold', mb: 4, fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif' }}>
+    <Container maxWidth="md" sx={{ py: 6, fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif', color: 'black' }}>
+      <Typography variant="h4" component="h1" sx={{ textAlign: 'center', fontWeight: 'bold', mb: 4, fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif' }}>
         Contact Us
       </Typography>
 
-      <Paper elevation={2} sx={{ p: 4, borderRadius: 2, bgcolor: 'white', border: '1px solid black', fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif' }}>
+      <Paper elevation={2} sx={{ p: 4, borderRadius: 2, bgcolor: 'white', border: '1px solid black', fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif' }}>
         <Stack spacing={2}>
-          <Accordion sx={{ fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif' }}>
+          <Accordion sx={{ fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif' }}>
             <AccordionSummary expandIcon={<ExpandMoreIcon sx={{ color: 'black' }} />}>
-              <Typography sx={{ fontWeight: 'bold', color: 'black', fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif' }}>
+              <Typography sx={{ fontWeight: 'bold', color: 'black', fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif' }}>
                 <BusinessIcon sx={{ verticalAlign: 'middle', mr: 1, color: 'black' }} /> Business Name
               </Typography>
             </AccordionSummary>
             <AccordionDetails>
-              <Typography sx={{ color: 'black', fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif' }}>
+              <Typography sx={{ color: 'black', fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif' }}>
                 MINICON & TRX TRENDS
               </Typography>
             </AccordionDetails>
           </Accordion>
 
-          <Accordion sx={{ fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif' }}>
+          <Accordion sx={{ fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif' }}>
             <AccordionSummary expandIcon={<ExpandMoreIcon sx={{ color: 'black' }} />}>
-              <Typography sx={{ fontWeight: 'bold', color: 'black', fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif' }}>
+              <Typography sx={{ fontWeight: 'bold', color: 'black', fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif' }}>
                 <LocationOnIcon sx={{ verticalAlign: 'middle', mr: 1, color: 'black' }} /> Address
               </Typography>
             </AccordionSummary>
             <AccordionDetails>
-              <Typography sx={{ color: 'black', fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif' }}>
+              <Typography sx={{ color: 'black', fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif' }}>
                 1/H/9 Rashmoni Bazar Road,<br />
                 Kolkata – 700010, West Bengal, India
               </Typography>
             </AccordionDetails>
           </Accordion>
 
-          <Accordion sx={{ fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif' }}>
+          <Accordion sx={{ fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif' }}>
             <AccordionSummary expandIcon={<ExpandMoreIcon sx={{ color: 'black' }} />}>
-              <Typography sx={{ fontWeight: 'bold', color: 'black', fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif' }}>
+              <Typography sx={{ fontWeight: 'bold', color: 'black', fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif' }}>
                 <EmailIcon sx={{ verticalAlign: 'middle', mr: 1, color: 'black' }} /> Email
               </Typography>
             </AccordionSummary>
             <AccordionDetails>
-              <Typography sx={{ fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif' }}>
-                <a href="mailto:miniconclothing@gmail.com" style={{ color: 'black', textDecoration: 'none', fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif' }}>
+              <Typography sx={{ fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif' }}>
+                <a href="mailto:miniconclothing@gmail.com" style={{ color: 'black', textDecoration: 'none', fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif' }}>
                   miniconclothing@gmail.com
                 </a>
               </Typography>
             </AccordionDetails>
           </Accordion>
 
-          <Accordion sx={{ fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif' }}>
+          <Accordion sx={{ fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif' }}>
             <AccordionSummary expandIcon={<ExpandMoreIcon sx={{ color: 'black' }} />}>
-              <Typography sx={{ fontWeight: 'bold', color: 'black', fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif' }}>
+              <Typography sx={{ fontWeight: 'bold', color: 'black', fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif' }}>
                 <WhatsAppIcon sx={{ verticalAlign: 'middle', mr: 1, color: 'black' }} /> WhatsApp Support
               </Typography>
             </AccordionSummary>
             <AccordionDetails>
-              <Typography sx={{ fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif' }}>
-                <a href="https://wa.me/918777073645" target="_blank" rel="noopener noreferrer" style={{ color: 'black', textDecoration: 'none', fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif' }}>
+              <Typography sx={{ fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif' }}>
+                <a href="https://wa.me/918777073645" target="_blank" rel="noopener noreferrer" style={{ color: 'black', textDecoration: 'none', fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif' }}>
                   +91 87770 73645
                 </a>
               </Typography>
             </AccordionDetails>
           </Accordion>
 
-          <Accordion sx={{ fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif' }}>
+          <Accordion sx={{ fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif' }}>
             <AccordionSummary expandIcon={<ExpandMoreIcon sx={{ color: 'black' }} />}>
-              <Typography sx={{ fontWeight: 'bold', color: 'black', fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif' }}>
+              <Typography sx={{ fontWeight: 'bold', color: 'black', fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif' }}>
                 <AccessTimeIcon sx={{ verticalAlign: 'middle', mr: 1, color: 'black' }} /> Business Hours
               </Typography>
             </AccordionSummary>
             <AccordionDetails>
-              <Typography sx={{ color: 'black', fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif' }}>
+              <Typography sx={{ color: 'black', fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif' }}>
                 Monday to Saturday – 11 AM to 6 PM IST
               </Typography>
             </AccordionDetails>
@@ -89,8 +89,8 @@ export default function ContactPage() {
         </Stack>
       </Paper>
 
-      <Box sx={{ mt: 4, textAlign: 'center', fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif' }}>
-        <Typography variant="body2" sx={{ color: 'black', fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif' }}>
+      <Box sx={{ mt: 4, textAlign: 'center', fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif' }}>
+        <Typography variant="body2" sx={{ color: 'black', fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif' }}>
           Need immediate assistance? Reach out to us through any of the methods above. We respond within 24 hours during business days.
         </Typography>
       </Box>

--- a/src/app/disclaimer/page.tsx
+++ b/src/app/disclaimer/page.tsx
@@ -16,14 +16,14 @@ const Disclaimer = () => {
       title: '1. Product Representation',
       content: (
         <>
-          <Typography sx={{ fontSize: '1rem', mb: 2, color: '#000', lineHeight: 1.7, fontFamily: 'sans-serif' }}>
+          <Typography sx={{ fontSize: '1rem', mb: 2, color: '#000', lineHeight: 1.7, fontFamily: 'Futura, sans-serif' }}>
             We make every effort to accurately display and describe our products, including colors, designs, sizes, and product images. However, due to differences in screen displays, lighting during photography, and printing methods:
           </Typography>
-          <Box component="ul" sx={{ fontSize: '1rem', color: '#000', ml: 3, mb: 2, lineHeight: 1.7, fontFamily: 'sans-serif' }}>
+          <Box component="ul" sx={{ fontSize: '1rem', color: '#000', ml: 3, mb: 2, lineHeight: 1.7, fontFamily: 'Futura, sans-serif' }}>
             <li>Minor variations in color, alignment, or print placement may occur.</li>
             <li>The actual product may slightly differ from the preview shown on the Website.</li>
           </Box>
-          <Typography sx={{ fontSize: '1rem', color: '#000', lineHeight: 1.7, fontFamily: 'sans-serif' }}>
+          <Typography sx={{ fontSize: '1rem', color: '#000', lineHeight: 1.7, fontFamily: 'Futura, sans-serif' }}>
             These differences shall not be considered defects and are not eligible for refunds or replacements unless explicitly stated otherwise.
           </Typography>
         </>
@@ -34,14 +34,14 @@ const Disclaimer = () => {
       title: '2. Made-to-Order Products',
       content: (
         <>
-          <Typography sx={{ fontSize: '1rem', mb: 2, color: '#000', lineHeight: 1.7, fontFamily: 'sans-serif' }}>
+          <Typography sx={{ fontSize: '1rem', mb: 2, color: '#000', lineHeight: 1.7, fontFamily: 'Futura, sans-serif' }}>
             All products sold on our Website are made-to-order and custom-printed upon receiving your order. As a result:
           </Typography>
-          <Box component="ul" sx={{ fontSize: '1rem', color: '#000', ml: 3, mb: 2, lineHeight: 1.7, fontFamily: 'sans-serif' }}>
+          <Box component="ul" sx={{ fontSize: '1rem', color: '#000', ml: 3, mb: 2, lineHeight: 1.7, fontFamily: 'Futura, sans-serif' }}>
             <li>Products may have slight variations between batches.</li>
             <li>Delivery timelines may vary based on demand, production schedules, and third-party logistics.</li>
           </Box>
-          <Typography sx={{ fontSize: '1rem', color: '#000', lineHeight: 1.7, fontFamily: 'sans-serif' }}>
+          <Typography sx={{ fontSize: '1rem', color: '#000', lineHeight: 1.7, fontFamily: 'Futura, sans-serif' }}>
             We shall not be held responsible for delays caused by external factors such as courier disruptions, public holidays, or unforeseen events.
           </Typography>
         </>
@@ -51,7 +51,7 @@ const Disclaimer = () => {
       id: 'panel3',
       title: '3. Third-Party Fulfilment',
       content: (
-        <Typography sx={{ fontSize: '1rem', color: '#000', lineHeight: 1.7, fontFamily: 'sans-serif' }}>
+        <Typography sx={{ fontSize: '1rem', color: '#000', lineHeight: 1.7, fontFamily: 'Futura, sans-serif' }}>
           We work with third-party fulfilment and print-on-demand service providers for manufacturing and shipping. While we maintain high standards in selecting partners, we are not liable for any direct, incidental, or consequential damages resulting from their performance or negligence.
         </Typography>
       )
@@ -61,10 +61,10 @@ const Disclaimer = () => {
       title: '4. Sizing and Fit',
       content: (
         <>
-          <Typography sx={{ fontSize: '1rem', mb: 2, color: '#000', lineHeight: 1.7, fontFamily: 'sans-serif' }}>
+          <Typography sx={{ fontSize: '1rem', mb: 2, color: '#000', lineHeight: 1.7, fontFamily: 'Futura, sans-serif' }}>
             Each product includes a detailed size chart. It is the customer&apos;s responsibility to review and select the correct size prior to placing an order. Returns or refunds will not be accepted for sizing issues unless:
           </Typography>
-          <Box component="ul" sx={{ fontSize: '1rem', color: '#000', ml: 3, lineHeight: 1.7, fontFamily: 'sans-serif' }}>
+          <Box component="ul" sx={{ fontSize: '1rem', color: '#000', ml: 3, lineHeight: 1.7, fontFamily: 'Futura, sans-serif' }}>
             <li>The product differs from the ordered size.</li>
             <li>A manufacturing defect is demonstrated with valid proof, including an unedited unboxing video and clear images.</li>
           </Box>
@@ -75,7 +75,7 @@ const Disclaimer = () => {
       id: 'panel5',
       title: '5. Intellectual Property',
       content: (
-        <Typography sx={{ fontSize: '1rem', color: '#000', lineHeight: 1.7, fontFamily: 'sans-serif' }}>
+        <Typography sx={{ fontSize: '1rem', color: '#000', lineHeight: 1.7, fontFamily: 'Futura, sans-serif' }}>
           All content, designs, artwork, logos, branding, and trademarks displayed on this Website are the exclusive intellectual property of Minicon Clothing. Any reproduction, redistribution, or unauthorized commercial use is strictly prohibited and may lead to legal action under applicable laws.
         </Typography>
       )
@@ -85,15 +85,15 @@ const Disclaimer = () => {
       title: '6. Limitation of Liability',
       content: (
         <>
-          <Typography sx={{ fontSize: '1rem', mb: 2, color: '#000', lineHeight: 1.7, fontFamily: 'sans-serif' }}>
+          <Typography sx={{ fontSize: '1rem', mb: 2, color: '#000', lineHeight: 1.7, fontFamily: 'Futura, sans-serif' }}>
             To the fullest extent permitted by law, Minicon Clothing shall not be liable for any:
           </Typography>
-          <Box component="ul" sx={{ fontSize: '1rem', color: '#000', ml: 3, mb: 2, lineHeight: 1.7, fontFamily: 'sans-serif' }}>
+          <Box component="ul" sx={{ fontSize: '1rem', color: '#000', ml: 3, mb: 2, lineHeight: 1.7, fontFamily: 'Futura, sans-serif' }}>
             <li>Direct or indirect damages resulting from product use or website access.</li>
             <li>Loss or damage due to courier delays, user error, or third-party service failure.</li>
             <li>Damages resulting from misuse of our services, including fraudulent COD orders, misuse of promotional offers, or improper unboxing.</li>
           </Box>
-          <Typography sx={{ fontSize: '1rem', color: '#000', lineHeight: 1.7, fontFamily: 'sans-serif' }}>
+          <Typography sx={{ fontSize: '1rem', color: '#000', lineHeight: 1.7, fontFamily: 'Futura, sans-serif' }}>
             Your sole and exclusive remedy for dissatisfaction with any product or service is to discontinue use of the Website.
           </Typography>
         </>
@@ -103,7 +103,7 @@ const Disclaimer = () => {
       id: 'panel7',
       title: '7. Governing Law & Jurisdiction',
       content: (
-        <Typography sx={{ fontSize: '1rem', color: '#000', lineHeight: 1.7, fontFamily: 'sans-serif' }}>
+        <Typography sx={{ fontSize: '1rem', color: '#000', lineHeight: 1.7, fontFamily: 'Futura, sans-serif' }}>
           This Disclaimer and any dispute arising from your use of this Website shall be governed by and construed in accordance with the laws of India. All disputes shall be subject to the exclusive jurisdiction of the courts located in Kolkata, India.
         </Typography>
       )
@@ -113,10 +113,10 @@ const Disclaimer = () => {
       title: '8. Contact Information',
       content: (
         <>
-          <Typography sx={{ fontSize: '1rem', mb: 2, color: '#000', lineHeight: 1.7, fontFamily: 'sans-serif' }}>
+          <Typography sx={{ fontSize: '1rem', mb: 2, color: '#000', lineHeight: 1.7, fontFamily: 'Futura, sans-serif' }}>
             For any questions or concerns related to this Disclaimer, you may contact us at:
           </Typography>
-          <Typography sx={{ fontSize: '1rem', color: '#000', lineHeight: 1.7, fontFamily: 'sans-serif' }}>
+          <Typography sx={{ fontSize: '1rem', color: '#000', lineHeight: 1.7, fontFamily: 'Futura, sans-serif' }}>
             📧 miniconclothing@gmail.com
           </Typography>
         </>
@@ -139,7 +139,7 @@ const Disclaimer = () => {
               fontWeight: 700,
               mb: 3,
               color: '#000',
-              fontFamily: 'sans-serif'
+              fontFamily: 'Futura, sans-serif'
             }}
           >
             DISCLAIMER
@@ -150,7 +150,7 @@ const Disclaimer = () => {
             mb: 2, 
             color: '#000',
             fontWeight: 600,
-            fontFamily: 'sans-serif'
+            fontFamily: 'Futura, sans-serif'
           }}>
             Effective Date: 1 July 2025
           </Typography>
@@ -160,7 +160,7 @@ const Disclaimer = () => {
             mb: 3, 
             color: '#000', 
             lineHeight: 1.7,
-            fontFamily: 'sans-serif'
+            fontFamily: 'Futura, sans-serif'
           }}>
             This Disclaimer (&quot;Disclaimer&quot;, &quot;Policy&quot;) governs the use of the website www.minicon.in (&quot;Website&quot;) and all related services, products, and content provided by MINICON & TRX TRNDS (&quot;Company&quot;, &quot;we&quot;, &quot;us&quot;, or &quot;our&quot;).
           </Typography>
@@ -170,7 +170,7 @@ const Disclaimer = () => {
             mb: 4, 
             color: '#000', 
             lineHeight: 1.7,
-            fontFamily: 'sans-serif'
+            fontFamily: 'Futura, sans-serif'
           }}>
             By accessing, browsing, or using this Website, you (&quot;User&quot;, &quot;you&quot;) agree to be bound by this Disclaimer. If you do not agree with any part of this Disclaimer, you must refrain from using our website or services.
           </Typography>
@@ -210,7 +210,7 @@ const Disclaimer = () => {
                   fontWeight: 600, 
                   fontSize: '1.25rem',
                   color: '#000',
-                  fontFamily: 'sans-serif'
+                  fontFamily: 'Futura, sans-serif'
                 }}>
                   {section.title}
                 </Typography>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,7 +24,7 @@ body {
 body {
   color: var(--foreground);
   background: var(--background);
-  font-family: sans-serif;
+  font-family: Futura, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/src/app/preCheckout/page.tsx
+++ b/src/app/preCheckout/page.tsx
@@ -179,7 +179,7 @@ const PreCheckout = () => {
       >
         {/* Title with Favorite Icon */}
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 0.5 }}>
-          <Typography sx={{ fontSize: "2.1rem", fontWeight: 700, fontFamily: 'sans-serif' }}>
+          <Typography sx={{ fontSize: "2.1rem", fontWeight: 700, fontFamily: 'Futura, sans-serif' }}>
             {product.title}
           </Typography>
           <IconButton
@@ -193,19 +193,19 @@ const PreCheckout = () => {
             <FavoriteIcon sx={{ fontSize: '1.8rem' }} />
           </IconButton>
         </Box>
-        <Typography sx={{ fontSize: "1.2rem", mb: 1, fontFamily: 'sans-serif', color: '#555' }}>
+        <Typography sx={{ fontSize: "1.2rem", mb: 1, fontFamily: 'Futura, sans-serif', color: '#555' }}>
           {product.subtitle}
         </Typography>
         {/* Price and Quantity */}
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 1 }}>
-          <Typography sx={{ fontSize: "1.6rem", fontWeight: 600, fontFamily: 'sans-serif', color: '#222' }}>
+          <Typography sx={{ fontSize: "1.6rem", fontWeight: 600, fontFamily: 'Futura, sans-serif', color: '#222' }}>
             ₹{product.price_after}
           </Typography>
           <Select
             value={quantity}
             onChange={e => setQuantity(Number(e.target.value))}
             size="small"
-            sx={{ minWidth: 60, fontFamily: 'sans-serif', fontWeight: 500 }}
+            sx={{ minWidth: 60, fontFamily: 'Futura, sans-serif', fontWeight: 500 }}
           >
             {[...Array(10)].map((_, i) => (
               <MenuItem key={i + 1} value={i + 1}>{i + 1}</MenuItem>
@@ -214,7 +214,7 @@ const PreCheckout = () => {
         </Box>
         {/* Size Buttons */}
         <Box sx={{ mb: 2 }}>
-          <Typography variant="subtitle1" fontWeight={700} mb={1} sx={{ fontFamily: 'sans-serif' }}>
+          <Typography variant="subtitle1" fontWeight={700} mb={1} sx={{ fontFamily: 'Futura, sans-serif' }}>
             Select size
           </Typography>
           {product.available_sizes.map((s) => (
@@ -231,7 +231,7 @@ const PreCheckout = () => {
                 margin: '1vh 0.5vw',
                 textTransform: 'none',
                 fontWeight: selectedSize === s ? 700 : 400,
-                fontFamily: 'sans-serif',
+                fontFamily: 'Futura, sans-serif',
                 bgcolor: selectedSize === s ? '#ffeaea' : 'white',
                 boxShadow: selectedSize === s ? 2 : 0,
               }}
@@ -239,7 +239,7 @@ const PreCheckout = () => {
               {s}
             </Button>
           ))}
-          <Typography variant="body2" sx={{ ml: 1, color: '#1976d2', display: 'inline', fontFamily: 'sans-serif', cursor: 'pointer' }}>
+          <Typography variant="body2" sx={{ ml: 1, color: '#1976d2', display: 'inline', fontFamily: 'Futura, sans-serif', cursor: 'pointer' }}>
             Notify Me
           </Typography>
         </Box>
@@ -259,7 +259,7 @@ const PreCheckout = () => {
               width: { xs: '100%', sm: 140 },
               height: 48,
               fontWeight: 700,
-              fontFamily: 'sans-serif',
+              fontFamily: 'Futura, sans-serif',
               mb: { xs: 1, sm: 0 },
               fontSize: 16,
               textTransform: 'none',
@@ -279,7 +279,7 @@ const PreCheckout = () => {
               width: { xs: '100%', sm: 140 },
               height: 48,
               fontWeight: 700,
-              fontFamily: 'sans-serif',
+              fontFamily: 'Futura, sans-serif',
               fontSize: 16,
               textTransform: 'none',
               borderRadius: 2,
@@ -297,7 +297,7 @@ const PreCheckout = () => {
         </Box>
         {/* Social Share Icons */}
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 2 }}>
-          <Typography variant="body2" sx={{ fontFamily: 'sans-serif', color: '#888' }}>Share</Typography>
+          <Typography variant="body2" sx={{ fontFamily: 'Futura, sans-serif', color: '#888' }}>Share</Typography>
           <WhatsAppIcon sx={{ color: '#25D366', cursor: 'pointer' }} />
           <FacebookIcon sx={{ color: '#4267B2', cursor: 'pointer' }} />
           <InstagramIcon sx={{ color: '#C13584', cursor: 'pointer' }} />
@@ -308,9 +308,9 @@ const PreCheckout = () => {
             placeholder="Enter Pincode"
             value={pincode}
             onChange={e => setPincode(e.target.value)}
-            sx={{ fontFamily: 'sans-serif', fontSize: 15, width: 160 }}
+            sx={{ fontFamily: 'Futura, sans-serif', fontSize: 15, width: 160 }}
           />
-          <Button variant="outlined" color="primary" sx={{ fontFamily: 'sans-serif', fontWeight: 600 }}>
+          <Button variant="outlined" color="primary" sx={{ fontFamily: 'Futura, sans-serif', fontWeight: 600 }}>
             CHECK
           </Button>
         </Box>
@@ -340,7 +340,7 @@ const PreCheckout = () => {
                 }
               }}
             >
-              <Typography variant="subtitle1" fontWeight={700} sx={{ fontFamily: 'sans-serif' }}>
+              <Typography variant="subtitle1" fontWeight={700} sx={{ fontFamily: 'Futura, sans-serif' }}>
                 DESCRIPTION
               </Typography>
             </AccordionSummary>
@@ -348,7 +348,7 @@ const PreCheckout = () => {
               <ul style={{ paddingLeft: 20, margin: 0 }}>
                 {PRODUCT_DESCRIPTION.map((line, idx) => (
                   <li key={idx} style={{ marginBottom: 3 }}>
-                    <Typography variant="body2" color="black" sx={{ fontFamily: 'sans-serif' }}>
+                    <Typography variant="body2" color="black" sx={{ fontFamily: 'Futura, sans-serif' }}>
                       {line}
                     </Typography>
                   </li>

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -9,7 +9,7 @@ const Privacy = () => {
       mx: 'auto', 
       px: { xs: 2, sm: 3, md: 4 }, 
       py: { xs: 3, sm: 5, md: 6 },
-      fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif'
+      fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif'
     }}>
       <Typography 
         variant="h3" 
@@ -17,7 +17,7 @@ const Privacy = () => {
         mb={4} 
         fontSize={{ xs: '2.2rem', md: '2.8rem' }}
         sx={{ 
-          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif',
+          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif',
           color: '#1a1a1a',
           textAlign: 'center',
           letterSpacing: '-0.02em'
@@ -32,7 +32,7 @@ const Privacy = () => {
         color="#4a4a4a" 
         lineHeight={1.8}
         sx={{ 
-          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif',
+          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif',
           fontWeight: 400
         }}
       >
@@ -48,7 +48,7 @@ const Privacy = () => {
         mb={3} 
         fontSize={{ xs: '1.4rem', md: '1.5rem' }}
         sx={{ 
-          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif',
+          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif',
           color: '#1a1a1a',
           letterSpacing: '-0.01em'
         }}
@@ -60,7 +60,7 @@ const Privacy = () => {
         mb={3} 
         color="#4a4a4a"
         sx={{ 
-          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif',
+          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif',
           fontWeight: 500
         }}
       >
@@ -73,10 +73,10 @@ const Privacy = () => {
           ml: { xs: 2, md: 3 }, 
           mb: { xs: 2.5, md: 3 }, 
           lineHeight: 1.8,
-          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif'
+          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif'
         }}
       >
-        <Typography component="span" fontWeight={600} color="#1a1a1a" sx={{ fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif' }}>• Personal Information:</Typography> Your name, postal address, email address, phone number, and payment details when you place an order or register on our website.
+        <Typography component="span" fontWeight={600} color="#1a1a1a" sx={{ fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif' }}>• Personal Information:</Typography> Your name, postal address, email address, phone number, and payment details when you place an order or register on our website.
       </Typography>
       <Typography 
         fontSize={{ xs: '1rem', md: '1.1rem' }} 
@@ -85,10 +85,10 @@ const Privacy = () => {
           ml: { xs: 2, md: 3 }, 
           mb: { xs: 2.5, md: 3 }, 
           lineHeight: 1.8,
-          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif'
+          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif'
         }}
       >
-        <Typography component="span" fontWeight={600} color="#1a1a1a" sx={{ fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif' }}>• Sensitive Personal Data:</Typography> Payment information and any other sensitive details needed to complete your purchase securely.
+        <Typography component="span" fontWeight={600} color="#1a1a1a" sx={{ fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif' }}>• Sensitive Personal Data:</Typography> Payment information and any other sensitive details needed to complete your purchase securely.
       </Typography>
       <Typography 
         fontSize={{ xs: '1rem', md: '1.1rem' }} 
@@ -97,10 +97,10 @@ const Privacy = () => {
           ml: { xs: 2, md: 3 }, 
           mb: { xs: 2.5, md: 3 }, 
           lineHeight: 1.8,
-          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif'
+          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif'
         }}
       >
-        <Typography component="span" fontWeight={600} color="#1a1a1a" sx={{ fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif' }}>• Technical Data:</Typography> IP address, browser type, device information, and usage data collected automatically through cookies and similar technologies.
+        <Typography component="span" fontWeight={600} color="#1a1a1a" sx={{ fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif' }}>• Technical Data:</Typography> IP address, browser type, device information, and usage data collected automatically through cookies and similar technologies.
       </Typography>
 
       <Box sx={{ borderBottom: '2px solid #e0e0e0', mb: 4 }} />
@@ -112,7 +112,7 @@ const Privacy = () => {
         mb={3} 
         fontSize={{ xs: '1.4rem', md: '1.5rem' }}
         sx={{ 
-          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif',
+          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif',
           color: '#1a1a1a',
           letterSpacing: '-0.01em'
         }}
@@ -124,7 +124,7 @@ const Privacy = () => {
         mb={3} 
         color="#4a4a4a"
         sx={{ 
-          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif',
+          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif',
           fontWeight: 500
         }}
       >
@@ -137,7 +137,7 @@ const Privacy = () => {
           ml: { xs: 2, md: 3 }, 
           mb: { xs: 1.5, md: 2 }, 
           lineHeight: 1.8,
-          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif'
+          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif'
         }}
       >
         • Process and fulfill your orders.
@@ -149,7 +149,7 @@ const Privacy = () => {
           ml: { xs: 2, md: 3 }, 
           mb: { xs: 1.5, md: 2 }, 
           lineHeight: 1.8,
-          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif'
+          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif'
         }}
       >
         • Communicate order status, updates, and promotional offers (with your consent).
@@ -161,7 +161,7 @@ const Privacy = () => {
           ml: { xs: 2, md: 3 }, 
           mb: { xs: 1.5, md: 2 }, 
           lineHeight: 1.8,
-          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif'
+          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif'
         }}
       >
         • Prevent fraudulent or illegal activities.
@@ -173,7 +173,7 @@ const Privacy = () => {
           ml: { xs: 2, md: 3 }, 
           mb: { xs: 1.5, md: 2 }, 
           lineHeight: 1.8,
-          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif'
+          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif'
         }}
       >
         • Improve website experience and services.
@@ -185,7 +185,7 @@ const Privacy = () => {
           ml: { xs: 2, md: 3 }, 
           mb: { xs: 2.5, md: 3 }, 
           lineHeight: 1.8,
-          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif'
+          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif'
         }}
       >
         • Comply with applicable legal and regulatory requirements.
@@ -200,7 +200,7 @@ const Privacy = () => {
         mb={3} 
         fontSize={{ xs: '1.4rem', md: '1.5rem' }}
         sx={{ 
-          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif',
+          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif',
           color: '#1a1a1a',
           letterSpacing: '-0.01em'
         }}
@@ -213,7 +213,7 @@ const Privacy = () => {
         color="#4a4a4a" 
         lineHeight={1.8}
         sx={{ 
-          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif'
+          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif'
         }}
       >
         By using our services or website, you consent to the collection, processing, and transfer of your data as described in this policy. We do not disclose your personal information to third parties except:
@@ -225,7 +225,7 @@ const Privacy = () => {
           ml: { xs: 2, md: 3 }, 
           mb: { xs: 1.5, md: 2 }, 
           lineHeight: 1.8,
-          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif'
+          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif'
         }}
       >
         • To trusted service providers (payment processors, couriers, IT service providers) who agree to keep your information confidential and use it only to provide services to us.
@@ -237,7 +237,7 @@ const Privacy = () => {
           ml: { xs: 2, md: 3 }, 
           mb: { xs: 2.5, md: 3 }, 
           lineHeight: 1.8,
-          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif'
+          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif'
         }}
       >
         • As required by law, court order, or government regulation.
@@ -252,7 +252,7 @@ const Privacy = () => {
         mb={3} 
         fontSize={{ xs: '1.4rem', md: '1.5rem' }}
         sx={{ 
-          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif',
+          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif',
           color: '#1a1a1a',
           letterSpacing: '-0.01em'
         }}
@@ -265,7 +265,7 @@ const Privacy = () => {
         color="#4a4a4a" 
         lineHeight={1.8}
         sx={{ 
-          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif'
+          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif'
         }}
       >
         We have implemented reasonable security practices and procedures to protect your personal data from unauthorized access, misuse, or disclosure, including encryption and secured servers.
@@ -276,7 +276,7 @@ const Privacy = () => {
         color="#4a4a4a" 
         lineHeight={1.8}
         sx={{ 
-          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif'
+          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif'
         }}
       >
         However, no method of electronic transmission or storage is 100% secure. You acknowledge and accept the risks of sharing information online.
@@ -291,7 +291,7 @@ const Privacy = () => {
         mb={3} 
         fontSize={{ xs: '1.4rem', md: '1.5rem' }}
         sx={{ 
-          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif',
+          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif',
           color: '#1a1a1a',
           letterSpacing: '-0.01em'
         }}
@@ -304,7 +304,7 @@ const Privacy = () => {
         color="#4a4a4a" 
         lineHeight={1.8}
         sx={{ 
-          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif'
+          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif'
         }}
       >
         Our website uses cookies to enhance user experience, analyze website traffic, and provide relevant advertisements. You can disable cookies in your browser settings, but this may affect website functionality.
@@ -319,7 +319,7 @@ const Privacy = () => {
         mb={3} 
         fontSize={{ xs: '1.4rem', md: '1.5rem' }}
         sx={{ 
-          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif',
+          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif',
           color: '#1a1a1a',
           letterSpacing: '-0.01em'
         }}
@@ -332,7 +332,7 @@ const Privacy = () => {
         color="#4a4a4a" 
         lineHeight={1.8}
         sx={{ 
-          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif'
+          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif'
         }}
       >
         We retain your personal information only as long as necessary to fulfill the purposes outlined, comply with legal obligations, resolve disputes, and enforce our agreements.
@@ -347,7 +347,7 @@ const Privacy = () => {
         mb={3} 
         fontSize={{ xs: '1.4rem', md: '1.5rem' }}
         sx={{ 
-          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif',
+          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif',
           color: '#1a1a1a',
           letterSpacing: '-0.01em'
         }}
@@ -359,7 +359,7 @@ const Privacy = () => {
         mb={3} 
         color="#4a4a4a"
         sx={{ 
-          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif',
+          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif',
           fontWeight: 500
         }}
       >
@@ -372,7 +372,7 @@ const Privacy = () => {
           ml: { xs: 2, md: 3 }, 
           mb: { xs: 1.5, md: 2 }, 
           lineHeight: 1.8,
-          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif'
+          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif'
         }}
       >
         • Access the personal data we hold about you.
@@ -384,7 +384,7 @@ const Privacy = () => {
           ml: { xs: 2, md: 3 }, 
           mb: { xs: 1.5, md: 2 }, 
           lineHeight: 1.8,
-          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif'
+          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif'
         }}
       >
         • Request corrections or updates to your information.
@@ -396,7 +396,7 @@ const Privacy = () => {
           ml: { xs: 2, md: 3 }, 
           mb: { xs: 1.5, md: 2 }, 
           lineHeight: 1.8,
-          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif'
+          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif'
         }}
       >
         • Withdraw consent to marketing communications.
@@ -408,7 +408,7 @@ const Privacy = () => {
           ml: { xs: 2, md: 3 }, 
           mb: { xs: 2.5, md: 3 }, 
           lineHeight: 1.8,
-          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif'
+          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif'
         }}
       >
         • Request deletion or blocking of your personal data (subject to legal requirements).
@@ -419,7 +419,7 @@ const Privacy = () => {
         color="#4a4a4a" 
         lineHeight={1.8}
         sx={{ 
-          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif'
+          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif'
         }}
       >
         To exercise these rights, please contact us at{' '}
@@ -429,7 +429,7 @@ const Privacy = () => {
             color: '#1976d2', 
             textDecoration: 'none',
             fontWeight: 500,
-            fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif'
+            fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif'
           }}
           onMouseEnter={(e) => (e.target as HTMLElement).style.textDecoration = 'underline'}
           onMouseLeave={(e) => (e.target as HTMLElement).style.textDecoration = 'none'}
@@ -447,7 +447,7 @@ const Privacy = () => {
         mb={3} 
         fontSize={{ xs: '1.4rem', md: '1.5rem' }}
         sx={{ 
-          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif',
+          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif',
           color: '#1a1a1a',
           letterSpacing: '-0.01em'
         }}
@@ -460,7 +460,7 @@ const Privacy = () => {
         color="#4a4a4a" 
         lineHeight={1.8}
         sx={{ 
-          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif'
+          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif'
         }}
       >
         Our website and services are not directed at children under 13 years of age. We do not knowingly collect data from children under this age.
@@ -475,7 +475,7 @@ const Privacy = () => {
         mb={3} 
         fontSize={{ xs: '1.4rem', md: '1.5rem' }}
         sx={{ 
-          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif',
+          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif',
           color: '#1a1a1a',
           letterSpacing: '-0.01em'
         }}
@@ -488,7 +488,7 @@ const Privacy = () => {
         color="#4a4a4a" 
         lineHeight={1.8}
         sx={{ 
-          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif'
+          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif'
         }}
       >
         We may update this Privacy Policy occasionally to reflect changes in laws or business practices. We encourage you to review this policy regularly. Continued use of the website constitutes acceptance of any updates.
@@ -503,7 +503,7 @@ const Privacy = () => {
         mb={3} 
         fontSize={{ xs: '1.4rem', md: '1.5rem' }}
         sx={{ 
-          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif',
+          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif',
           color: '#1a1a1a',
           letterSpacing: '-0.01em'
         }}
@@ -516,7 +516,7 @@ const Privacy = () => {
         color="#4a4a4a" 
         lineHeight={1.8}
         sx={{ 
-          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif'
+          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif'
         }}
       >
         For any questions, concerns, or requests related to your privacy, please reach out to us:
@@ -527,7 +527,7 @@ const Privacy = () => {
         color="#4a4a4a" 
         lineHeight={1.8}
         sx={{ 
-          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif'
+          fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif'
         }}
       >
         Email:{' '}
@@ -537,7 +537,7 @@ const Privacy = () => {
             color: '#1976d2', 
             textDecoration: 'none',
             fontWeight: 500,
-            fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif'
+            fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", Futura, sans-serif'
           }}
           onMouseEnter={(e) => (e.target as HTMLElement).style.textDecoration = 'underline'}
           onMouseLeave={(e) => (e.target as HTMLElement).style.textDecoration = 'none'}

--- a/src/app/returnPolicy/page.tsx
+++ b/src/app/returnPolicy/page.tsx
@@ -16,7 +16,7 @@ const ReturnPolicy = () => {
       question: 'Can I return or exchange my product?',
       content: (
         <>
-          <Typography sx={{ fontSize: '1rem', lineHeight: 1.8, mb: 3, color: '#000', fontFamily: 'sans-serif' }}>
+          <Typography sx={{ fontSize: '1rem', lineHeight: 1.8, mb: 3, color: '#000', fontFamily: 'Futura, sans-serif' }}>
             You can request a return or exchange only if the item is:
           </Typography>
           
@@ -30,7 +30,7 @@ const ReturnPolicy = () => {
               <Typography 
                 key={index}
                 component="li" 
-                sx={{ fontSize: '1rem', lineHeight: 1.8, color: '#000', mb: 1, fontFamily: 'sans-serif' }}
+                sx={{ fontSize: '1rem', lineHeight: 1.8, color: '#000', mb: 1, fontFamily: 'Futura, sans-serif' }}
               >
                 {item}
               </Typography>
@@ -38,13 +38,13 @@ const ReturnPolicy = () => {
           </Box>
           
           <Box sx={{ bgcolor: '#f5f5f5', p: 3, borderRadius: 1 }}>
-            <Typography sx={{ fontSize: '0.95rem', lineHeight: 1.7, mb: 2, color: '#000', fontFamily: 'sans-serif' }}>
+            <Typography sx={{ fontSize: '0.95rem', lineHeight: 1.7, mb: 2, color: '#000', fontFamily: 'Futura, sans-serif' }}>
               • All returned items must be new, unused, and in their original condition.
             </Typography>
-            <Typography sx={{ fontSize: '0.95rem', lineHeight: 1.7, mb: 2, color: '#000', fontFamily: 'sans-serif' }}>
+            <Typography sx={{ fontSize: '0.95rem', lineHeight: 1.7, mb: 2, color: '#000', fontFamily: 'Futura, sans-serif' }}>
               • Returns will not be accepted if the brand tag or labels is removed from the product.
             </Typography>
-            <Typography sx={{ fontSize: '0.95rem', lineHeight: 1.7, color: '#000', fontWeight: 600, fontFamily: 'sans-serif' }}>
+            <Typography sx={{ fontSize: '0.95rem', lineHeight: 1.7, color: '#000', fontWeight: 600, fontFamily: 'Futura, sans-serif' }}>
               📌 Change of mind or wrong size orders are not eligible for free return/exchange. You&apos;ll need to place a new order at your cost.
             </Typography>
           </Box>
@@ -56,10 +56,10 @@ const ReturnPolicy = () => {
       question: 'What is the time frame to raise a return request?',
       content: (
         <Box sx={{ bgcolor: '#f5f5f5', p: 3, borderRadius: 1 }}>
-          <Typography sx={{ fontSize: '1rem', lineHeight: 1.8, mb: 2, color: '#000', fontFamily: 'sans-serif' }}>
+          <Typography sx={{ fontSize: '1rem', lineHeight: 1.8, mb: 2, color: '#000', fontFamily: 'Futura, sans-serif' }}>
             All return/exchange claims must be made within <strong>5 days</strong> of product delivery.
           </Typography>
-          <Typography sx={{ fontSize: '1rem', lineHeight: 1.8, color: '#000', fontWeight: 600, fontFamily: 'sans-serif' }}>
+          <Typography sx={{ fontSize: '1rem', lineHeight: 1.8, color: '#000', fontWeight: 600, fontFamily: 'Futura, sans-serif' }}>
             After this period, the return request will be declined.
           </Typography>
         </Box>
@@ -70,7 +70,7 @@ const ReturnPolicy = () => {
       question: 'What evidence is required to submit a return request?',
       content: (
         <>
-          <Typography sx={{ fontSize: '1rem', lineHeight: 1.8, mb: 3, color: '#000', fontFamily: 'sans-serif' }}>
+          <Typography sx={{ fontSize: '1rem', lineHeight: 1.8, mb: 3, color: '#000', fontFamily: 'Futura, sans-serif' }}>
             To submit a valid claim, you must provide:
           </Typography>
           
@@ -83,7 +83,7 @@ const ReturnPolicy = () => {
               <Typography 
                 key={index}
                 component="li" 
-                sx={{ fontSize: '1rem', lineHeight: 1.8, color: '#000', mb: 1, fontFamily: 'sans-serif' }}
+                sx={{ fontSize: '1rem', lineHeight: 1.8, color: '#000', mb: 1, fontFamily: 'Futura, sans-serif' }}
               >
                 {item}
               </Typography>
@@ -91,7 +91,7 @@ const ReturnPolicy = () => {
           </Box>
           
           <Box sx={{ bgcolor: '#f5f5f5', p: 3, borderRadius: 1 }}>
-            <Typography sx={{ fontSize: '1rem', lineHeight: 1.8, color: '#000', fontWeight: 600, fontFamily: 'sans-serif' }}>
+            <Typography sx={{ fontSize: '1rem', lineHeight: 1.8, color: '#000', fontWeight: 600, fontFamily: 'Futura, sans-serif' }}>
               📩 Email all documents to: <strong>miniconclothing@gmail.com</strong>
             </Typography>
           </Box>
@@ -103,13 +103,13 @@ const ReturnPolicy = () => {
       question: 'Can I return or exchange if I ordered the wrong size?',
       content: (
         <Box sx={{ bgcolor: '#f5f5f5', p: 3, borderRadius: 1 }}>
-          <Typography sx={{ fontSize: '1rem', lineHeight: 1.8, mb: 2, color: '#000', fontWeight: 600, fontFamily: 'sans-serif' }}>
+          <Typography sx={{ fontSize: '1rem', lineHeight: 1.8, mb: 2, color: '#000', fontWeight: 600, fontFamily: 'Futura, sans-serif' }}>
             Unfortunately, we do not offer returns or exchanges for incorrect size selection.
           </Typography>
-          <Typography sx={{ fontSize: '1rem', lineHeight: 1.8, mb: 2, color: '#000', fontFamily: 'sans-serif' }}>
+          <Typography sx={{ fontSize: '1rem', lineHeight: 1.8, mb: 2, color: '#000', fontFamily: 'Futura, sans-serif' }}>
             However, you may place a new order at your own expense if you&apos;d like to get a different size.
           </Typography>
-          <Typography sx={{ fontSize: '1rem', lineHeight: 1.8, color: '#000', fontFamily: 'sans-serif' }}>
+          <Typography sx={{ fontSize: '1rem', lineHeight: 1.8, color: '#000', fontFamily: 'Futura, sans-serif' }}>
             <strong>Tip:</strong> Always refer to our size chart before placing your order.
           </Typography>
         </Box>
@@ -120,18 +120,18 @@ const ReturnPolicy = () => {
       question: 'What if the product was damaged while opening?',
       content: (
         <Box sx={{ bgcolor: '#f5f5f5', p: 3, borderRadius: 1 }}>
-          <Typography sx={{ fontSize: '1rem', lineHeight: 1.8, mb: 2, color: '#000', fontWeight: 600, fontFamily: 'sans-serif' }}>
+          <Typography sx={{ fontSize: '1rem', lineHeight: 1.8, mb: 2, color: '#000', fontWeight: 600, fontFamily: 'Futura, sans-serif' }}>
             If the item was accidentally cut or damaged while opening (e.g. with scissors), we cannot approve a return unless:
           </Typography>
           <Box component="ul" sx={{ pl: 3, mb: 2 }}>
-            <Typography component="li" sx={{ fontSize: '1rem', lineHeight: 1.8, color: '#000', mb: 1, fontFamily: 'sans-serif' }}>
+            <Typography component="li" sx={{ fontSize: '1rem', lineHeight: 1.8, color: '#000', mb: 1, fontFamily: 'Futura, sans-serif' }}>
               A clear unboxing video shows the condition before damage
             </Typography>
-            <Typography component="li" sx={{ fontSize: '1rem', lineHeight: 1.8, color: '#000', mb: 1, fontFamily: 'sans-serif' }}>
+            <Typography component="li" sx={{ fontSize: '1rem', lineHeight: 1.8, color: '#000', mb: 1, fontFamily: 'Futura, sans-serif' }}>
               The damage wasn&apos;t caused during unpacking
             </Typography>
           </Box>
-          <Typography sx={{ fontSize: '1rem', lineHeight: 1.8, color: '#000', fontWeight: 600, fontFamily: 'sans-serif' }}>
+          <Typography sx={{ fontSize: '1rem', lineHeight: 1.8, color: '#000', fontWeight: 600, fontFamily: 'Futura, sans-serif' }}>
             Please unbox your order carefully.
           </Typography>
         </Box>
@@ -142,10 +142,10 @@ const ReturnPolicy = () => {
       question: 'How do I arrange a reverse pickup (if eligible)?',
       content: (
         <Box sx={{ bgcolor: '#f5f5f5', p: 3, borderRadius: 1 }}>
-          <Typography sx={{ fontSize: '1rem', lineHeight: 1.8, mb: 2, color: '#000', fontFamily: 'sans-serif' }}>
+          <Typography sx={{ fontSize: '1rem', lineHeight: 1.8, mb: 2, color: '#000', fontFamily: 'Futura, sans-serif' }}>
             In select approved return cases, we may help arrange a reverse pickup within 5 days of delivery.
           </Typography>
-          <Typography sx={{ fontSize: '1rem', lineHeight: 1.8, color: '#000', fontWeight: 600, fontFamily: 'sans-serif' }}>
+          <Typography sx={{ fontSize: '1rem', lineHeight: 1.8, color: '#000', fontWeight: 600, fontFamily: 'Futura, sans-serif' }}>
             📦 This will be confirmed via email with instructions.
           </Typography>
         </Box>
@@ -156,11 +156,11 @@ const ReturnPolicy = () => {
       question: 'What should I do if the package looks damaged on delivery?',
       content: (
         <>
-          <Typography sx={{ fontSize: '1rem', lineHeight: 1.8, mb: 3, color: '#000', fontFamily: 'sans-serif' }}>
+          <Typography sx={{ fontSize: '1rem', lineHeight: 1.8, mb: 3, color: '#000', fontFamily: 'Futura, sans-serif' }}>
             Inspect the package before signing from the courier.
           </Typography>
           
-          <Typography sx={{ fontSize: '1rem', lineHeight: 1.8, mb: 2, color: '#000', fontFamily: 'sans-serif' }}>
+          <Typography sx={{ fontSize: '1rem', lineHeight: 1.8, mb: 2, color: '#000', fontFamily: 'Futura, sans-serif' }}>
             If you notice visible damage:
           </Typography>
           
@@ -173,7 +173,7 @@ const ReturnPolicy = () => {
               <Typography 
                 key={index}
                 component="li" 
-                sx={{ fontSize: '1rem', lineHeight: 1.8, color: '#000', mb: 1, fontFamily: 'sans-serif' }}
+                sx={{ fontSize: '1rem', lineHeight: 1.8, color: '#000', mb: 1, fontFamily: 'Futura, sans-serif' }}
               >
                 {item}
               </Typography>
@@ -181,7 +181,7 @@ const ReturnPolicy = () => {
           </Box>
           
           <Box sx={{ bgcolor: '#f5f5f5', p: 3, borderRadius: 1 }}>
-            <Typography sx={{ fontSize: '1rem', lineHeight: 1.8, color: '#000', fontWeight: 600, fontFamily: 'sans-serif' }}>
+            <Typography sx={{ fontSize: '1rem', lineHeight: 1.8, color: '#000', fontWeight: 600, fontFamily: 'Futura, sans-serif' }}>
               This helps us raise claims with the courier partner.
             </Typography>
           </Box>
@@ -210,7 +210,7 @@ const ReturnPolicy = () => {
               fontWeight: 700,
               mb: 3,
               color: '#000',
-              fontFamily: 'sans-serif'
+              fontFamily: 'Futura, sans-serif'
             }}
           >
             Return & Exchange Policy
@@ -221,7 +221,7 @@ const ReturnPolicy = () => {
               fontSize: { xs: '1rem', md: '1.125rem' },
               lineHeight: 1.8,
               color: '#000',
-              fontFamily: 'sans-serif',
+              fontFamily: 'Futura, sans-serif',
               mb: 1
             }}
           >
@@ -233,7 +233,7 @@ const ReturnPolicy = () => {
               fontSize: { xs: '1rem', md: '1.125rem' },
               lineHeight: 1.8,
               color: '#000',
-              fontFamily: 'sans-serif'
+              fontFamily: 'Futura, sans-serif'
             }}
           >
             Here are some key return and exchange guidelines.
@@ -275,7 +275,7 @@ const ReturnPolicy = () => {
                     fontWeight: 600, 
                     fontSize: '1.125rem',
                     color: '#000',
-                    fontFamily: 'sans-serif'
+                    fontFamily: 'Futura, sans-serif'
                   }}
                 >
                   {item.question}
@@ -305,7 +305,7 @@ const ReturnPolicy = () => {
               fontWeight: 700,
               mb: 3,
               color: '#000',
-              fontFamily: 'sans-serif'
+              fontFamily: 'Futura, sans-serif'
             }}
           >
             Still Need Help?
@@ -317,7 +317,7 @@ const ReturnPolicy = () => {
               lineHeight: 1.8,
               mb: 3,
               color: '#000',
-              fontFamily: 'sans-serif'
+              fontFamily: 'Futura, sans-serif'
             }}
           >
             Reach out anytime at:
@@ -333,7 +333,7 @@ const ReturnPolicy = () => {
               borderRadius: 1,
               fontWeight: 600,
               fontSize: '1rem',
-              fontFamily: 'sans-serif'
+              fontFamily: 'Futura, sans-serif'
             }}
           >
             📧 miniconclothing@gmail.com
@@ -345,7 +345,7 @@ const ReturnPolicy = () => {
               lineHeight: 1.8,
               color: '#666',
               mt: 2,
-              fontFamily: 'sans-serif'
+              fontFamily: 'Futura, sans-serif'
             }}
           >
             We&apos;ll respond within 24–48 hours.

--- a/src/app/shipping/page.tsx
+++ b/src/app/shipping/page.tsx
@@ -74,7 +74,7 @@ export default function ShippingPage() {
               fontWeight: 700,
               mb: 3,
               color: '#000',
-              fontFamily: 'sans-serif'
+              fontFamily: 'Futura, sans-serif'
             }}
           >
             📦 SHIPPING – FREQUENTLY ASKED QUESTIONS (FAQS)
@@ -85,7 +85,7 @@ export default function ShippingPage() {
               fontSize: { xs: '1rem', md: '1.125rem' },
               lineHeight: 1.8,
               color: '#000',
-              fontFamily: 'sans-serif'
+              fontFamily: 'Futura, sans-serif'
             }}
           >
             Everything you need to know about our shipping process, delivery times, and tracking your orders.
@@ -127,7 +127,7 @@ export default function ShippingPage() {
                     fontWeight: 600, 
                     fontSize: '1.125rem',
                     color: '#000',
-                    fontFamily: 'sans-serif'
+                    fontFamily: 'Futura, sans-serif'
                   }}
                 >
                   {item.question}
@@ -138,7 +138,7 @@ export default function ShippingPage() {
                   fontSize: '1rem', 
                   lineHeight: 1.8, 
                   color: '#000', 
-                  fontFamily: 'sans-serif',
+                  fontFamily: 'Futura, sans-serif',
                   whiteSpace: 'pre-line'
                 }}>
                   {item.answer}
@@ -165,7 +165,7 @@ export default function ShippingPage() {
               fontWeight: 700,
               mb: 3,
               color: '#000',
-              fontFamily: 'sans-serif'
+              fontFamily: 'Futura, sans-serif'
             }}
           >
             Still Need Help?
@@ -177,7 +177,7 @@ export default function ShippingPage() {
               lineHeight: 1.8,
               mb: 3,
               color: '#000',
-              fontFamily: 'sans-serif'
+              fontFamily: 'Futura, sans-serif'
             }}
           >
             Reach out anytime at:
@@ -193,7 +193,7 @@ export default function ShippingPage() {
               borderRadius: 1,
               fontWeight: 600,
               fontSize: '1rem',
-              fontFamily: 'sans-serif'
+              fontFamily: 'Futura, sans-serif'
             }}
           >
             📧 miniconclothing@gmail.com
@@ -205,7 +205,7 @@ export default function ShippingPage() {
               lineHeight: 1.8,
               color: '#666',
               mt: 2,
-              fontFamily: 'sans-serif'
+              fontFamily: 'Futura, sans-serif'
             }}
           >
             We&apos;ll respond within 24–48 hours.
@@ -218,14 +218,14 @@ export default function ShippingPage() {
             color: '#666', 
             mb: 2,
             fontSize: '1rem',
-            fontFamily: 'sans-serif'
+            fontFamily: 'Futura, sans-serif'
           }}>
             We&apos;re committed to providing you with the best shipping experience possible.
           </Typography>
           <Typography sx={{ 
             color: '#666',
             fontSize: '0.875rem',
-            fontFamily: 'sans-serif'
+            fontFamily: 'Futura, sans-serif'
           }}>
             For the most up-to-date shipping information, please check your order confirmation email.
           </Typography>


### PR DESCRIPTION
## Summary
- update the global stylesheet to use Futura
- change all components and pages to reference `Futura, sans-serif`
- update the SVG logo to use Futura

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b4597db64832fb49a441aa5fecc51